### PR TITLE
fix: Issue with 'login' return Ok even though the login failed.

### DIFF
--- a/src/client/authentication.rs
+++ b/src/client/authentication.rs
@@ -14,11 +14,18 @@ impl super::Api {
             .header("refer", api.base_url.read().await.to_string())
             .send()
             .await?;
-        if res.status().is_success() {
-            Ok(api)
-        } else {
-            Err(Error::AuthFailed)
+
+        if !res.status().is_success() {
+            return Err(Error::AuthFailed);
         }
+
+        // Checks if the result from the API is one of a success.
+        let login = res.text().await?;
+        if login.to_lowercase() == "fails." {
+            return Err(Error::AuthFailed);
+        }
+
+        Ok(api)
     }
 
     /// Logout the client instance


### PR DESCRIPTION
As per the 5.0 webUI API Documentation for the login section: https://github.com/qbittorrent/qBittorrent/wiki/WebUI-API-(qBittorrent-5.0)#login

> <p><strong>Returns:</strong></p>
>
> HTTP Status Code | Scenario
> -- | --
> 403 | User's IP is banned for too many failed login attempts
> 200 | All other scenarios

Error code 403 does not catch the times when the user logs in with invalid credentials, that is caught under error code 200. Hence, we need an extra check to make sure the user has successfully logged in before returning the api client.

Note: This is one way of implementing this. There are other potential ways including:
- Reversing the check (Checking for `Ok.` instead 
- Cookies maybe? I haven't dug deep into this, but it looks like it what the v4.x crate does (Line in question: https://github.com/George-Miao/qbit/blob/6b63683e9e4a2512b799459e1331f41388f57bba/src/lib.rs#L1435) 