### PR TITLE
fix: Spelling

### DIFF
--- a/src/client/application.rs
+++ b/src/client/application.rs
@@ -66,11 +66,11 @@ impl super::Api {
 
     /// Get application preferences
     ///
-    /// Retuns struct with several fields representing the application's settings.
-    pub async fn preferances(&self) -> Result<Preferences, Error> {
+    /// Returns struct with several fields representing the application's settings.
+    pub async fn preferences(&self) -> Result<Preferences, Error> {
         let url = self._build_url("/api/v2/app/preferences").await?;
 
-        let preferances = self
+        let preferences = self
             .http_client
             .get(url)
             .send()
@@ -78,11 +78,11 @@ impl super::Api {
             .json::<Preferences>()
             .await?;
 
-        Ok(preferances)
+        Ok(preferences)
     }
 
     /// Set application preferences
-    pub async fn set_preferances(&self, preferences: Preferences) -> Result<(), Error> {
+    pub async fn set_preferences(&self, preferences: Preferences) -> Result<(), Error> {
         let url = self._build_url("/api/v2/app/setPreferences").await?;
 
         let mut form = multipart::Form::new();
@@ -94,10 +94,10 @@ impl super::Api {
     }
 
     /// Get default save path
-    pub async fn deafult_save_path(&self) -> Result<String, Error> {
+    pub async fn default_save_path(&self) -> Result<String, Error> {
         let url = self._build_url("/api/v2/app/defaultSavePath").await?;
 
-        let preferances = self
+        let preferences = self
             .http_client
             .get(url)
             .send()
@@ -105,6 +105,6 @@ impl super::Api {
             .json::<String>()
             .await?;
 
-        Ok(preferances)
+        Ok(preferences)
     }
 }

--- a/src/client/torrent.rs
+++ b/src/client/torrent.rs
@@ -158,7 +158,7 @@ impl super::Api {
     ///
     /// # Arguments
     ///
-    /// * `hash` - The hash of the torrent you want to get the pice states of.
+    /// * `hash` - The hash of the torrent you want to get the piece states of.
     pub async fn pieces_states(&self, hash: &str) -> Result<Vec<PiecesState>, Error> {
         let mut url = self._build_url("api/v2/torrents/pieceStates").await?;
 
@@ -937,7 +937,7 @@ impl super::Api {
     /// * `hashes` - The hashes of the torrents you want to set automatic torrent management of.
     /// If `None` all torrents are selected.
     /// * `enable`
-    pub async fn set_automatic_torrent_managment(
+    pub async fn set_automatic_torrent_management(
         &self,
         hashes: Option<Vec<&str>>,
         enable: bool,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,7 +3,7 @@ mod error;
 
 /// Data object models.
 pub mod models;
-/// Parameter bjects.
+/// Parameter objects.
 pub mod parameters;
 
 pub use client::Api;

--- a/src/models/application.rs
+++ b/src/models/application.rs
@@ -3,7 +3,7 @@ use std::collections::HashMap;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use serde_repr::{Deserialize_repr, Serialize_repr};
 
-/// Torrent info resposne object
+/// Torrent info response object
 #[derive(Debug, Deserialize)]
 pub struct TorrentInfo {
     /// Time (Unix Epoch) when the torrent was added to the client
@@ -104,7 +104,7 @@ pub struct TorrentInfo {
     pub upspeed: i64,
 }
 
-/// Build info resposne data object.
+/// Build info response data object.
 #[derive(Debug, Deserialize)]
 pub struct BuildInfo {
     /// QT version
@@ -119,7 +119,7 @@ pub struct BuildInfo {
     pub bitness: u8,
 }
 
-/// Preferences resposne data object.
+/// Preferences response data object.
 #[derive(Debug, Deserialize, Serialize)]
 pub struct Preferences {
     /// Currently selected language (e.g. en_GB for English)

--- a/src/models/log.rs
+++ b/src/models/log.rs
@@ -19,7 +19,7 @@ pub struct LogItem {
 
 /// Log types
 ///
-/// Log levels used by the loger
+/// Log levels used by the logger
 #[derive(Debug, Deserialize_repr, Serialize_repr)]
 #[repr(u8)]
 pub enum LogType {

--- a/src/models/sync.rs
+++ b/src/models/sync.rs
@@ -41,7 +41,7 @@ pub struct Category {
     pub save_path: String,
 }
 
-/// Server state resposne data object.
+/// Server state response data object.
 #[derive(Debug, Deserialize)]
 pub struct ServerState {
     /// Alltime download
@@ -49,7 +49,7 @@ pub struct ServerState {
     /// Alltime upload
     pub alltime_ul: i64,
     pub average_time_queue: i64,
-    /// Conection status
+    /// Connection status
     pub connection_status: ConnectionStatus,
     /// DHT nodes
     pub dht_nodes: i64,
@@ -70,13 +70,13 @@ pub struct ServerState {
     /// Queued IO jobs
     pub queued_io_jobs: i64,
     pub queueing: bool,
-    pub read_cache_hits: String,     // Is interger in format of string
-    pub read_cache_overload: String, // Is interger in format of string
+    pub read_cache_hits: String,     // Is integer in format of string
+    pub read_cache_overload: String, // Is integer in format of string
     /// Refresh Interval
     pub refresh_interval: i64,
     /// Total buffer size
     pub total_buffers_size: i64,
-    /// Total peer conections
+    /// Total peer connections
     pub total_peer_connections: i64,
     /// Total queued size
     pub total_queued_size: i64,
@@ -91,10 +91,10 @@ pub struct ServerState {
     pub use_alt_speed_limits: bool,
     /// Use subcategories
     pub use_subcategories: bool,
-    pub write_cache_overload: String, // Is interger in format of string
+    pub write_cache_overload: String, // Is integer in format of string
 }
 
-/// Peers resposne data object.
+/// Peers response data object.
 #[derive(Debug, Deserialize)]
 pub struct PeersData {
     /// Response ID
@@ -108,10 +108,10 @@ pub struct PeersData {
     pub peers_removed: Option<Vec<String>>,
 }
 
-/// Peer resposne data object.
+/// Peer response data object.
 #[derive(Debug, Deserialize)]
 pub struct Peer {
-    /// Client used by the peer. (μTorrent, qBittorrent, ect...)
+    /// Client used by the peer. (μTorrent, qBittorrent, etc...)
     pub client: Option<String>,
     /// Used connection
     pub connection: Option<String>,
@@ -121,7 +121,7 @@ pub struct Peer {
     pub country_code: Option<String>,
     /// Download speed
     pub dl_speed: Option<i64>,
-    /// Total downlaoded
+    /// Total downloaded
     pub downloaded: Option<i64>,
     /// Files/contents
     pub files: Option<String>,

--- a/src/parameters.rs
+++ b/src/parameters.rs
@@ -20,7 +20,7 @@ pub struct TorrentListParams {
 }
 
 impl TorrentListParams {
-    pub fn deafult() -> Self {
+    pub fn default() -> Self {
         Self {
             filter: None,
             category: None,
@@ -259,7 +259,7 @@ pub struct TorrentAddUrls {
 }
 
 impl TorrentAddUrls {
-    pub fn deafult(urls: Vec<String>) -> Self {
+    pub fn default(urls: Vec<String>) -> Self {
         Self {
             urls,
             savepath: None,


### PR DESCRIPTION
As well as some functions renaming, due to the spelling mistakes.

Spell check was done via the help of [typos](https://github.com/crate-ci/typos)