### PR TITLE
feat: RSS API endpoint implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,11 +104,11 @@ Supported Qbittorrent version: `5.0`
 - [x] Get all items
 - [x] Mark as read
 - [x] Refresh item
-- [ ] Set auto-downloading rule
-- [ ] Rename auto-downloading rule
-- [ ] Remove auto-downloading rule
-- [ ] Get all auto-downloading rules
-- [ ] Get all articles matching a rule
+- [x] Set auto-downloading rule
+- [x] Rename auto-downloading rule
+- [x] Remove auto-downloading rule
+- [x] Get all auto-downloading rules
+- [x] Get all articles matching a rule
 
 ### Search
 

--- a/README.md
+++ b/README.md
@@ -97,13 +97,13 @@ Supported Qbittorrent version: `5.0`
 
 ### RSS (experimental)
 
-- [ ] Add folder
-- [ ] Add feed
-- [ ] Remove item
-- [ ] Move item
-- [ ] Get all items
-- [ ] Mark as read
-- [ ] Refresh item
+- [x] Add folder
+- [x] Add feed
+- [x] Remove item
+- [x] Move item
+- [x] Get all items
+- [x] Mark as read
+- [x] Refresh item
 - [ ] Set auto-downloading rule
 - [ ] Rename auto-downloading rule
 - [ ] Remove auto-downloading rule

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -8,6 +8,7 @@ use crate::error::Error;
 mod application;
 mod authentication;
 mod log;
+mod rss;
 mod sync;
 mod torrent;
 mod transfer;

--- a/src/client/rss.rs
+++ b/src/client/rss.rs
@@ -1,6 +1,6 @@
 use reqwest::multipart;
 
-use crate::error::Error;
+use crate::{error::Error, models::RssFeedCollection};
 
 impl super::Api {
     /// Add RSS folder
@@ -32,6 +32,106 @@ impl super::Api {
         if let Some(path) = path {
             form = form.text("path", path.to_string());
         }
+
+        self.http_client.post(url).multipart(form).send().await?;
+
+        Ok(())
+    }
+
+    /// Remove RSS item
+    ///
+    /// Removes folder or feed.
+    ///
+    /// # Arguments
+    /// * `path` - Full path of removed item (e.g. "The Pirate Bay\Top100")
+    pub async fn rss_remove_item(&self, path: &str) -> Result<(), Error> {
+        let url = self._build_url("api/v2/rss/removeItem").await?;
+
+        let mut form = multipart::Form::new();
+        form = form.text("path", path.to_string());
+
+        self.http_client.post(url).multipart(form).send().await?;
+
+        Ok(())
+    }
+
+    /// Move RSS item
+    ///
+    /// Moves/renames folder or feed.
+    ///
+    /// # Arguments
+    /// * `item_path` - Current full path of item (e.g. "The Pirate Bay\Top100")
+    /// * `dest_path` - New full path of item (e.g. "The Pirate Bay")
+    pub async fn rss_move_item(&self, item_path: &str, dest_path: &str) -> Result<(), Error> {
+        let url = self._build_url("api/v2/rss/moveItem").await?;
+
+        let mut form = multipart::Form::new();
+        form = form.text("itemPath", item_path.to_string());
+        form = form.text("destPath", dest_path.to_string());
+
+        self.http_client.post(url).multipart(form).send().await?;
+
+        Ok(())
+    }
+
+    /// Get all RSS items
+    ///
+    /// # Arguments
+    ///
+    /// * `withData` - True if you need current feed articles
+    ///
+    /// TODO: Need to test a bit later on what `with_data` do!?
+    pub async fn rss_items(&self, with_data: bool) -> Result<RssFeedCollection, Error> {
+        let mut url = self._build_url("api/v2/rss/items").await?;
+
+        let mut query = url.query_pairs_mut();
+        query.append_pair("withData", &with_data.to_string());
+        drop(query);
+
+        let feed = self
+            .http_client
+            .get(url)
+            .send()
+            .await?
+            .json::<RssFeedCollection>()
+            .await?;
+
+        Ok(feed)
+    }
+
+    /// Mark as read
+    ///
+    /// If `article_id` is set only the article is marked as read otherwise the whole
+    /// feed is going to be marked as read.
+    ///
+    /// # Arguments
+    /// * `path` - Current full path of item (e.g. "The Pirate Bay\Top100")
+    /// * `article_id` - ID of article
+    pub async fn rss_mark_as_read(&self, path: &str, article_id: Option<u64>) -> Result<(), Error> {
+        let url = self._build_url("api/v2/rss/moveItem").await?;
+
+        let mut form = multipart::Form::new();
+        form = form.text("path", path.to_string());
+        if let Some(article_id) = article_id {
+            form = form.text("articleId", article_id.to_string());
+        }
+
+        self.http_client.post(url).multipart(form).send().await?;
+
+        Ok(())
+    }
+
+    /// Refresh RSS item
+    ///
+    /// Refreshes folder or feed.
+    ///
+    /// # Arguments
+    /// * `item_path` - Current full path of item (e.g. "The Pirate Bay\Top100")
+    pub async fn rss_refresh_item(&self, item_path: &str) -> Result<(), Error> {
+        let url = self._build_url("api/v2/rss/refreshItem").await?;
+
+        let mut form = multipart::Form::new();
+        form = form.text("itemPath", item_path.to_string());
 
         self.http_client.post(url).multipart(form).send().await?;
 

--- a/src/client/rss.rs
+++ b/src/client/rss.rs
@@ -1,0 +1,21 @@
+use reqwest::multipart;
+
+use crate::error::Error;
+
+impl super::Api {
+    /// Add RSS folder
+    ///
+    /// # Arguments
+    ///
+    /// * `path` - Full path of added folder (e.g. "The Pirate Bay\Top100")
+    pub async fn rss_add_folder(&self, path: &str) -> Result<(), Error> {
+        let url = self._build_url("api/v2/rss/addFolder").await?;
+
+        let mut form = multipart::Form::new();
+        form = form.text("path", path.to_string());
+
+        self.http_client.post(url).multipart(form).send().await?;
+
+        Ok(())
+    }
+}

--- a/src/client/rss.rs
+++ b/src/client/rss.rs
@@ -87,7 +87,10 @@ impl super::Api {
     ///
     /// * `withData` - True if you need current feed articles
     ///
-    /// TODO: Need to test a bit later on what `with_data` do!?
+    /// # Returns
+    /// A `HashMap` where the keys are feed names and the values are `RssFeedCollection` objects.
+    /// The `RssFeedCollection` contains detailed information about each RSS feed, including its
+    /// articles if `withData` is set to true. `RssFeedCollection` can have nested `RssFeedCollection`
     pub async fn rss_items(
         &self,
         with_data: bool,

--- a/src/client/rss.rs
+++ b/src/client/rss.rs
@@ -88,7 +88,10 @@ impl super::Api {
     /// * `withData` - True if you need current feed articles
     ///
     /// TODO: Need to test a bit later on what `with_data` do!?
-    pub async fn rss_items(&self, with_data: bool) -> Result<RssFeedCollection, Error> {
+    pub async fn rss_items(
+        &self,
+        with_data: bool,
+    ) -> Result<HashMap<String, RssFeedCollection>, Error> {
         let mut url = self._build_url("api/v2/rss/items").await?;
 
         let mut query = url.query_pairs_mut();
@@ -100,7 +103,7 @@ impl super::Api {
             .get(url)
             .send()
             .await?
-            .json::<RssFeedCollection>()
+            .json::<HashMap<String, RssFeedCollection>>()
             .await?;
 
         Ok(feed)

--- a/src/client/rss.rs
+++ b/src/client/rss.rs
@@ -33,9 +33,11 @@ impl super::Api {
         let url = self._build_url("api/v2/rss/addFeed").await?;
 
         let mut form = multipart::Form::new();
-        form = form.text("feed_url", feed_url.to_string());
+        form = form.text("url", feed_url.to_string());
         if let Some(path) = path {
             form = form.text("path", path.to_string());
+        } else {
+            form = form.text("path", "".to_string());
         }
 
         self.http_client.post(url).multipart(form).send().await?;
@@ -207,11 +209,11 @@ impl super::Api {
         Ok(rules)
     }
 
-    /// Get all RSS rules articals
+    /// Get all RSS rules articles
     ///
     /// # Arguments
     /// * `name` - Rule name (e.g. "Linux")
-    pub async fn rss_rules_articals(
+    pub async fn rss_rules_articles(
         &self,
         name: &str,
     ) -> Result<HashMap<String, Vec<String>>, Error> {

--- a/src/client/rss.rs
+++ b/src/client/rss.rs
@@ -12,7 +12,7 @@ impl super::Api {
     ///
     /// # Arguments
     ///
-    /// * `path` - Full path of added folder (e.g. "The Pirate Bay\Top100")
+    /// * `path` - Full path of added folder. Use `\\` insted of `/` as the delimiter. (e.g. "The Pirate Bay\\Top100")
     pub async fn rss_add_folder(&self, path: &str) -> Result<(), Error> {
         let url = self._build_url("api/v2/rss/addFolder").await?;
 
@@ -28,7 +28,7 @@ impl super::Api {
     ///
     /// # Arguments
     /// * `feed_url` - URL of RSS feed (e.g. "http://thepiratebay.org/rss//top100/200")
-    /// * `path` - Full path of added folder (e.g. "The Pirate Bay\Top100")
+    /// * `path` - Full path of added feed. Use `\\` insted of `/` as the delimiter. (e.g. "The Pirate Bay\\Top100")
     pub async fn rss_add_feed(&self, feed_url: &str, path: Option<&str>) -> Result<(), Error> {
         let url = self._build_url("api/v2/rss/addFeed").await?;
 
@@ -48,7 +48,7 @@ impl super::Api {
     /// Removes folder or feed.
     ///
     /// # Arguments
-    /// * `path` - Full path of removed item (e.g. "The Pirate Bay\Top100")
+    /// * `path` - Full path of removed item. Use `\\` insted of `/` as the delimiter. (e.g. "The Pirate Bay\\Top100")
     pub async fn rss_remove_item(&self, path: &str) -> Result<(), Error> {
         let url = self._build_url("api/v2/rss/removeItem").await?;
 
@@ -65,8 +65,8 @@ impl super::Api {
     /// Moves/renames folder or feed.
     ///
     /// # Arguments
-    /// * `item_path` - Current full path of item (e.g. "The Pirate Bay\Top100")
-    /// * `dest_path` - New full path of item (e.g. "The Pirate Bay")
+    /// * `item_path` - Current full path of item. Use `\\` insted of `/` as the delimiter. (e.g. "The Pirate Bay\\Top100")
+    /// * `dest_path` - New full path of item. Use `\\` insted of `/` as the delimiter. (e.g. "The Pirate Bay")
     pub async fn rss_move_item(&self, item_path: &str, dest_path: &str) -> Result<(), Error> {
         let url = self._build_url("api/v2/rss/moveItem").await?;
 
@@ -110,7 +110,7 @@ impl super::Api {
     /// feed is going to be marked as read.
     ///
     /// # Arguments
-    /// * `path` - Current full path of item (e.g. "The Pirate Bay\Top100")
+    /// * `path` - Current full path of item. Use `\\` insted of `/` as the delimiter. (e.g. "The Pirate Bay\\Top100")
     /// * `article_id` - ID of article
     pub async fn rss_mark_as_read(&self, path: &str, article_id: Option<u64>) -> Result<(), Error> {
         let url = self._build_url("api/v2/rss/moveItem").await?;
@@ -131,7 +131,7 @@ impl super::Api {
     /// Refreshes folder or feed.
     ///
     /// # Arguments
-    /// * `item_path` - Current full path of item (e.g. "The Pirate Bay\Top100")
+    /// * `item_path` - Current full path of item. Use `\\` insted of `/` as the delimiter. (e.g. "The Pirate Bay\\Top100")
     pub async fn rss_refresh_item(&self, item_path: &str) -> Result<(), Error> {
         let url = self._build_url("api/v2/rss/refreshItem").await?;
 

--- a/src/client/rss.rs
+++ b/src/client/rss.rs
@@ -18,4 +18,23 @@ impl super::Api {
 
         Ok(())
     }
+
+    /// Add RSS feed
+    ///
+    /// # Arguments
+    /// * `feed_url` - URL of RSS feed (e.g. "http://thepiratebay.org/rss//top100/200")
+    /// * `path` - Full path of added folder (e.g. "The Pirate Bay\Top100")
+    pub async fn rss_add_feed(&self, feed_url: &str, path: Option<&str>) -> Result<(), Error> {
+        let url = self._build_url("api/v2/rss/addFeed").await?;
+
+        let mut form = multipart::Form::new();
+        form = form.text("feed_url", feed_url.to_string());
+        if let Some(path) = path {
+            form = form.text("path", path.to_string());
+        }
+
+        self.http_client.post(url).multipart(form).send().await?;
+
+        Ok(())
+    }
 }

--- a/src/client/rss.rs
+++ b/src/client/rss.rs
@@ -12,7 +12,7 @@ impl super::Api {
     ///
     /// # Arguments
     ///
-    /// * `path` - Full path of added folder. Use `\\` insted of `/` as the delimiter. (e.g. "The Pirate Bay\\Top100")
+    /// * `path` - Full path of added folder. Use `\\` instead of `/` as the delimiter. (e.g. "The Pirate Bay\\Top100")
     pub async fn rss_add_folder(&self, path: &str) -> Result<(), Error> {
         let url = self._build_url("api/v2/rss/addFolder").await?;
 
@@ -28,7 +28,7 @@ impl super::Api {
     ///
     /// # Arguments
     /// * `feed_url` - URL of RSS feed (e.g. "http://thepiratebay.org/rss//top100/200")
-    /// * `path` - Full path of added feed. Use `\\` insted of `/` as the delimiter. (e.g. "The Pirate Bay\\Top100")
+    /// * `path` - Full path of added feed. Use `\\` instead of `/` as the delimiter. (e.g. "The Pirate Bay\\Top100")
     pub async fn rss_add_feed(&self, feed_url: &str, path: Option<&str>) -> Result<(), Error> {
         let url = self._build_url("api/v2/rss/addFeed").await?;
 
@@ -50,7 +50,7 @@ impl super::Api {
     /// Removes folder or feed.
     ///
     /// # Arguments
-    /// * `path` - Full path of removed item. Use `\\` insted of `/` as the delimiter. (e.g. "The Pirate Bay\\Top100")
+    /// * `path` - Full path of removed item. Use `\\` instead of `/` as the delimiter. (e.g. "The Pirate Bay\\Top100")
     pub async fn rss_remove_item(&self, path: &str) -> Result<(), Error> {
         let url = self._build_url("api/v2/rss/removeItem").await?;
 
@@ -67,8 +67,8 @@ impl super::Api {
     /// Moves/renames folder or feed.
     ///
     /// # Arguments
-    /// * `item_path` - Current full path of item. Use `\\` insted of `/` as the delimiter. (e.g. "The Pirate Bay\\Top100")
-    /// * `dest_path` - New full path of item. Use `\\` insted of `/` as the delimiter. (e.g. "The Pirate Bay")
+    /// * `item_path` - Current full path of item. Use `\\` instead of `/` as the delimiter. (e.g. "The Pirate Bay\\Top100")
+    /// * `dest_path` - New full path of item. Use `\\` instead of `/` as the delimiter. (e.g. "The Pirate Bay")
     pub async fn rss_move_item(&self, item_path: &str, dest_path: &str) -> Result<(), Error> {
         let url = self._build_url("api/v2/rss/moveItem").await?;
 
@@ -118,7 +118,7 @@ impl super::Api {
     /// feed is going to be marked as read.
     ///
     /// # Arguments
-    /// * `path` - Current full path of item. Use `\\` insted of `/` as the delimiter. (e.g. "The Pirate Bay\\Top100")
+    /// * `path` - Current full path of item. Use `\\` instead of `/` as the delimiter. (e.g. "The Pirate Bay\\Top100")
     /// * `article_id` - ID of article
     pub async fn rss_mark_as_read(&self, path: &str, article_id: Option<u64>) -> Result<(), Error> {
         let url = self._build_url("api/v2/rss/moveItem").await?;
@@ -139,7 +139,7 @@ impl super::Api {
     /// Refreshes folder or feed.
     ///
     /// # Arguments
-    /// * `item_path` - Current full path of item. Use `\\` insted of `/` as the delimiter. (e.g. "The Pirate Bay\\Top100")
+    /// * `item_path` - Current full path of item. Use `\\` instead of `/` as the delimiter. (e.g. "The Pirate Bay\\Top100")
     pub async fn rss_refresh_item(&self, item_path: &str) -> Result<(), Error> {
         let url = self._build_url("api/v2/rss/refreshItem").await?;
 

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -2,12 +2,14 @@ use serde::Deserialize;
 
 mod application;
 mod log;
+mod rss;
 mod sync;
 mod torrent;
 mod transfer;
 
 pub use application::*;
 pub use log::*;
+pub use rss::*;
 pub use sync::*;
 pub use torrent::*;
 pub use transfer::*;

--- a/src/models/rss.rs
+++ b/src/models/rss.rs
@@ -2,16 +2,65 @@ use std::collections::HashMap;
 
 use serde::{Deserialize, Serialize};
 
+/// This module defines structures for representing RSS feeds collections.
 #[derive(Debug, Deserialize)]
 #[serde(untagged)]
-pub enum RssFeed {
-    Item(String),
-    Folder(HashMap<String, String>),
+pub enum RssFeedCollection {
+    /// Represents a full RSS feed object containing detailed information about the feed.
+    Feed(RssFeed),
+    /// Represents a folder containing multiple RSS feeds.
+    Folder(HashMap<String, RssFeedCollection>),
+    /// Represents a short base object with minimal information about the feed.
+    FeedBase(RssFeedBase),
 }
 
-#[derive(Debug, Deserialize)]
-pub struct RssFeedCollection {
-    pub feeds: HashMap<String, RssFeed>,
+/// Represents a base RSS feed object with minimal information.
+#[derive(Debug, Deserialize, Serialize)]
+pub struct RssFeedBase {
+    /// Unique identifier for the RSS feed.
+    uid: String,
+    /// URL of the RSS feed.
+    url: String,
+}
+
+/// Represents a detailed RSS feed object containing full information.
+#[derive(Debug, Deserialize, Serialize)]
+pub struct RssFeed {
+    /// Unique identifier for the RSS feed.
+    uid: String,
+    /// Title of the RSS feed.
+    title: String,
+    /// URL of the RSS feed.
+    url: String,
+    /// The last build date of the RSS feed.
+    #[serde(rename = "lastBuildDate")]
+    last_build_date: String,
+    /// Indicates whether the RSS feed has encountered an error.
+    #[serde(rename = "hasError")]
+    has_error: bool,
+    /// Indicates whether the RSS feed is currently loading.
+    #[serde(rename = "isLoading")]
+    is_loading: bool,
+    /// List of articles associated with the RSS feed.
+    articles: Vec<RssArticle>,
+}
+
+/// Represents an article within an RSS feed.
+#[derive(Debug, Deserialize, Serialize)]
+pub struct RssArticle {
+    /// Identifier for the article.
+    id: String,
+    /// Title of the article.
+    title: String,
+    /// URL of the torrent associated with the article.
+    #[serde(rename = "torrentURL")]
+    torrent_url: String,
+    /// Link to the article.
+    link: String,
+    /// Description of the article.
+    description: String,
+    /// Publication date of the article.
+    date: String,
 }
 
 #[derive(Debug, Deserialize, Serialize)]

--- a/src/models/rss.rs
+++ b/src/models/rss.rs
@@ -1,0 +1,15 @@
+use std::collections::HashMap;
+
+use serde::Deserialize;
+
+#[derive(Debug, Deserialize)]
+#[serde(untagged)]
+pub enum RssFeed {
+    Item(String),
+    Folder(HashMap<String, String>),
+}
+
+#[derive(Debug, Deserialize)]
+pub struct RssFeedCollection {
+    pub feeds: HashMap<String, RssFeed>,
+}

--- a/src/models/rss.rs
+++ b/src/models/rss.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Deserialize)]
 #[serde(untagged)]
@@ -12,4 +12,46 @@ pub enum RssFeed {
 #[derive(Debug, Deserialize)]
 pub struct RssFeedCollection {
     pub feeds: HashMap<String, RssFeed>,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct RssRule {
+    /// Whether the rule is enabled
+    enabled: bool,
+    /// The substring that the torrent name must contain
+    #[serde(rename = "mustContain")]
+    must_contain: String,
+    /// The substring that the torrent name must not contain
+    #[serde(rename = "mustNotContain")]
+    must_not_contain: String,
+    /// Enable regex mode in "mustContain" and "mustNotContain"
+    #[serde(rename = "useRegex")]
+    use_regex: bool,
+    /// Episode filter definition
+    #[serde(rename = "episodeFilter")]
+    episode_filter: String,
+    /// Enable smart episode filter
+    #[serde(rename = "smartFilter")]
+    smart_filter: bool,
+    /// The list of episode IDs already matched by smart filter
+    #[serde(rename = "previouslyMatchedEpisodes")]
+    previously_matched_episodes: Vec<String>,
+    /// The feed URLs the rule applied to
+    #[serde(rename = "affectedFeeds")]
+    affected_feeds: Vec<String>,
+    /// Ignore sunsequent rule matches
+    #[serde(rename = "ignoreDays")]
+    ignore_days: i64,
+    /// The rule last match time
+    #[serde(rename = "lastMatch")]
+    last_match: String,
+    /// Add matched torrent in paused mode
+    #[serde(rename = "addPaused")]
+    add_paused: bool,
+    /// Assign category to the torrent
+    #[serde(rename = "assignedCategory")]
+    assigned_category: String,
+    /// Save torrent to the given directory
+    #[serde(rename = "savePath")]
+    save_path: String,
 }


### PR DESCRIPTION
Implemented RSS endpoints from the [qBittorrent-5.0 RSS Documentation](https://github.com/qbittorrent/qBittorrent/wiki/WebUI-API-(qBittorrent-5.0)#rss-experimental) 

- Add folder
- Add feed
- Remove item
- Move item
- Get all items
- Mark as read
- Refresh item
- Set auto-downloading rule
- Rename auto-downloading rule
- Remove auto-downloading rule
- Get all auto-downloading rules
- Get all articles matching a rule