### PR TITLE
Clippy fixes

### DIFF
--- a/src/client/authentication.rs
+++ b/src/client/authentication.rs
@@ -114,7 +114,7 @@ impl super::Api {
                 .map_err(|e| {
                     Error::AuthFailed(format!(
                         "Failed to pars SID cookie to str. err: {}",
-                        e.to_string()
+                        e
                     ))
                 })?
                 .split(';')

--- a/src/client/authentication.rs
+++ b/src/client/authentication.rs
@@ -10,7 +10,7 @@ impl super::Api {
     /// # Arguments
     /// * `url` - The base URL of the API service.
     /// * `credentials` - The credentials to use for authentication.
-    /// 
+    ///
     pub async fn new_login(url: &str, credentials: Credentials) -> Result<Self, Error> {
         let mut api = Self::new(url)?;
 
@@ -29,7 +29,7 @@ impl super::Api {
     /// * `url` - The base URL of the API service.
     /// * `username` - The username for authentication.
     /// * `password` - The password for authentication.
-    /// 
+    ///
     pub async fn new_login_username_password(
         url: &str,
         username: impl Into<String>,
@@ -44,13 +44,13 @@ impl super::Api {
     ///
     /// This method allows you to login using the credentials stored in the API state.
     /// If the user is already logged in, it will check the validity of the session.
-    /// 
+    ///
     /// [official documentation](https://github.com/qbittorrent/qBittorrent/wiki/WebUI-API-(qBittorrent-5.0)#login)
     ///
     /// # Arguments
     /// * `credentials` - The credentials to use for authentication.
     /// * `force` - If true, forces a login even if already logged in.
-    /// 
+    ///
     pub async fn login(&mut self, force: bool) -> Result<(), Error> {
         // check if already login (aka cookie set)
         if self.state.read().await.as_cookie().is_some() && !force {
@@ -63,13 +63,10 @@ impl super::Api {
 
         if let Some(cred) = self.state.read().await.as_credentials() {
             if cred.is_empty() {
-                return Err(Error::AuthFailed(
-                    format!(
-                        "Credential filed is empty and missing values: {}",
-                        cred.to_string()
-                    )
-                    .to_string(),
-                ));
+                return Err(Error::AuthFailed(format!(
+                    "Credential filed is empty and missing values: {}",
+                    cred
+                )));
             }
         } else {
             return Err(Error::AuthFailed("Credentials are not set".to_string()));
@@ -112,10 +109,7 @@ impl super::Api {
                 .unwrap()
                 .to_str()
                 .map_err(|e| {
-                    Error::AuthFailed(format!(
-                        "Failed to pars SID cookie to str. err: {}",
-                        e
-                    ))
+                    Error::AuthFailed(format!("Failed to pars SID cookie to str. err: {}", e))
                 })?
                 .split(';')
                 .next()
@@ -134,7 +128,7 @@ impl super::Api {
     /// # Arguments
     /// * `url` - The base URL of the API service.
     /// * `sid_cookie` - The session ID cookie for authentication.
-    /// 
+    ///
     pub async fn new_from_cookie(url: &str, sid_cookie: impl Into<&str>) -> Result<Self, Error> {
         let mut api = Self::new(url)?;
 
@@ -154,7 +148,7 @@ impl super::Api {
     /// Logout the client instance
     ///
     /// This will clear the current session and remove the SID cookie.
-    /// 
+    ///
     /// [official documentation](https://github.com/qbittorrent/qBittorrent/wiki/WebUI-API-(qBittorrent-5.0)#logout)
     ///
     pub async fn logout(&self) -> Result<(), Error> {

--- a/src/client/rss.rs
+++ b/src/client/rss.rs
@@ -9,13 +9,13 @@ use crate::{
 
 impl super::Api {
     /// Add RSS folder
-    /// 
+    ///
     /// [official documentation](https://github.com/qbittorrent/qBittorrent/wiki/WebUI-API-(qBittorrent-5.0)#add-folder)
     ///
     /// # Arguments
     ///
     /// * `path` - Full path of added folder. Use `\\` instead of `/` as the delimiter. (e.g. "The Pirate Bay\\Top100")
-    /// 
+    ///
     pub async fn rss_add_folder(&self, path: &str) -> Result<(), Error> {
         let mut form = multipart::Form::new();
         form = form.text("path", path.to_string());
@@ -32,11 +32,11 @@ impl super::Api {
     /// Add RSS feed
     ///
     /// [official documentation](https://github.com/qbittorrent/qBittorrent/wiki/WebUI-API-(qBittorrent-5.0)#add-feed)
-    /// 
+    ///
     /// # Arguments
     /// * `feed_url` - URL of RSS feed (e.g. "http://thepiratebay.org/rss//top100/200")
     /// * `path` - Full path of added feed. Use `\\` instead of `/` as the delimiter. (e.g. "The Pirate Bay\\Top100")
-    /// 
+    ///
     pub async fn rss_add_feed(&self, feed_url: &str, path: Option<&str>) -> Result<(), Error> {
         let mut form = multipart::Form::new();
         form = form.text("url", feed_url.to_string());
@@ -58,12 +58,12 @@ impl super::Api {
     /// Remove RSS item
     ///
     /// Removes folder or feed.
-    /// 
+    ///
     /// [official documentation](https://github.com/qbittorrent/qBittorrent/wiki/WebUI-API-(qBittorrent-5.0)#remove-item)
     ///
     /// # Arguments
     /// * `path` - Full path of removed item. Use `\\` instead of `/` as the delimiter. (e.g. "The Pirate Bay\\Top100")
-    /// 
+    ///
     pub async fn rss_remove_item(&self, path: &str) -> Result<(), Error> {
         let mut form = multipart::Form::new();
         form = form.text("path", path.to_string());
@@ -80,13 +80,13 @@ impl super::Api {
     /// Move RSS item
     ///
     /// Moves/renames folder or feed.
-    /// 
+    ///
     /// [official documentation](https://github.com/qbittorrent/qBittorrent/wiki/WebUI-API-(qBittorrent-5.0)#move-item)
     ///
     /// # Arguments
     /// * `item_path` - Current full path of item. Use `\\` instead of `/` as the delimiter. (e.g. "The Pirate Bay\\Top100")
     /// * `dest_path` - New full path of item. Use `\\` instead of `/` as the delimiter. (e.g. "The Pirate Bay")
-    /// 
+    ///
     pub async fn rss_move_item(&self, item_path: &str, dest_path: &str) -> Result<(), Error> {
         let mut form = multipart::Form::new();
         form = form.text("itemPath", item_path.to_string());
@@ -102,7 +102,7 @@ impl super::Api {
     }
 
     /// Get all RSS items
-    /// 
+    ///
     /// [official documentation](https://github.com/qbittorrent/qBittorrent/wiki/WebUI-API-(qBittorrent-5.0)#get-all-items)
     ///
     /// # Arguments
@@ -113,13 +113,12 @@ impl super::Api {
     /// A `HashMap` where the keys are feed names and the values are `RssFeedCollection` objects.
     /// The `RssFeedCollection` contains detailed information about each RSS feed, including its
     /// articles if `withData` is set to true. `RssFeedCollection` can have nested `RssFeedCollection`
-    /// 
+    ///
     pub async fn rss_items(
         &self,
         with_data: bool,
     ) -> Result<HashMap<String, RssFeedCollection>, Error> {
-        let mut query = vec![];
-        query.push(("withData", with_data));
+        let query = vec![("withData", with_data)];
 
         let feed = self
             ._get("rss/items")
@@ -137,13 +136,13 @@ impl super::Api {
     ///
     /// If `article_id` is set only the article is marked as read otherwise the whole
     /// feed is going to be marked as read.
-    /// 
+    ///
     /// [official documentation](https://github.com/qbittorrent/qBittorrent/wiki/WebUI-API-(qBittorrent-5.0)#mark-as-read)
     ///
     /// # Arguments
     /// * `path` - Current full path of item. Use `\\` instead of `/` as the delimiter. (e.g. "The Pirate Bay\\Top100")
     /// * `article_id` - ID of article
-    /// 
+    ///
     pub async fn rss_mark_as_read(&self, path: &str, article_id: Option<u64>) -> Result<(), Error> {
         let mut form = multipart::Form::new();
         form = form.text("path", path.to_string());
@@ -163,12 +162,12 @@ impl super::Api {
     /// Refresh RSS item
     ///
     /// Refreshes folder or feed.
-    /// 
+    ///
     /// [official documentation](https://github.com/qbittorrent/qBittorrent/wiki/WebUI-API-(qBittorrent-5.0)#refresh-item)
     ///
     /// # Arguments
     /// * `item_path` - Current full path of item. Use `\\` instead of `/` as the delimiter. (e.g. "The Pirate Bay\\Top100")
-    /// 
+    ///
     pub async fn rss_refresh_item(&self, item_path: &str) -> Result<(), Error> {
         let mut form = multipart::Form::new();
         form = form.text("itemPath", item_path.to_string());
@@ -183,13 +182,13 @@ impl super::Api {
     }
 
     /// Set RSS rule
-    /// 
+    ///
     /// [official documentation](https://github.com/qbittorrent/qBittorrent/wiki/WebUI-API-(qBittorrent-5.0)#set-auto-downloading-rule)
     ///
     /// # Arguments
     /// * `name` - Rule name (e.g. "Punisher")
     /// * `def` - rule definition
-    /// 
+    ///
     pub async fn rss_set_rule(&self, name: &str, def: RssRule) -> Result<(), Error> {
         let mut form = multipart::Form::new();
         form = form.text("ruleName", name.to_string());
@@ -205,13 +204,13 @@ impl super::Api {
     }
 
     /// Rename RSS rule
-    /// 
+    ///
     /// [official documentation](https://github.com/qbittorrent/qBittorrent/wiki/WebUI-API-(qBittorrent-5.0)#rename-auto-downloading-rule)
     ///
     /// # Arguments
     /// * `name` - Rule name (e.g. "Punisher")
     /// * `new_name` - New rule name (e.g. "The Punisher")
-    /// 
+    ///
     pub async fn rss_rename_rule(&self, name: &str, new_name: &str) -> Result<(), Error> {
         let mut form = multipart::Form::new();
         form = form.text("ruleName", name.to_string());
@@ -227,12 +226,12 @@ impl super::Api {
     }
 
     /// Remove RSS rule
-    /// 
+    ///
     /// [official documentation](https://github.com/qbittorrent/qBittorrent/wiki/WebUI-API-(qBittorrent-5.0)#remove-auto-downloading-rule)
     ///
     /// # Arguments
     /// * `name` - Rule name (e.g. "Punisher")
-    /// 
+    ///
     pub async fn rss_remove_rule(&self, name: &str) -> Result<(), Error> {
         let mut form = multipart::Form::new();
         form = form.text("ruleName", name.to_string());
@@ -247,9 +246,9 @@ impl super::Api {
     }
 
     /// Get all RSS rules
-    /// 
+    ///
     /// [official documentation](https://github.com/qbittorrent/qBittorrent/wiki/WebUI-API-(qBittorrent-5.0)#get-all-auto-downloading-rules)
-    /// 
+    ///
     pub async fn rss_rules(&self) -> Result<HashMap<String, RssRule>, Error> {
         let rules = self
             ._get("rss/rules")
@@ -263,18 +262,17 @@ impl super::Api {
     }
 
     /// Get all RSS rules articles
-    /// 
+    ///
     /// [official documentation](https://github.com/qbittorrent/qBittorrent/wiki/WebUI-API-(qBittorrent-5.0)#get-all-articles-matching-a-rule)
     ///
     /// # Arguments
     /// * `name` - Rule name (e.g. "Linux")
-    /// 
+    ///
     pub async fn rss_rules_articles(
         &self,
         name: &str,
     ) -> Result<HashMap<String, Vec<String>>, Error> {
-        let mut query = vec![];
-        query.push(("ruleName", name));
+        let query = vec![("ruleName", name)];
 
         let articles = self
             ._get("rss/matchingArticles")

--- a/src/client/search.rs
+++ b/src/client/search.rs
@@ -7,16 +7,16 @@ use crate::{
 
 impl super::Api {
     /// Start search
-    /// 
+    ///
     /// [official documentation](https://github.com/qbittorrent/qBittorrent/wiki/WebUI-API-(qBittorrent-5.0)#start-search)
     ///
     /// # Arguments
     /// * `pattern` - Pattern to search for (e.g. "Ubuntu 18.04")
     /// * `plugins` - Plugins to use for searching (e.g. "legittorrents"). Supports
-    /// multiple plugins separated by `|`. Also supports `all` and `enabled`
+    ///   multiple plugins separated by `|`. Also supports `all` and `enabled`
     /// * `category` - Categories to limit your search to (e.g. "legittorrents").
-    /// Available categories depend on the specified plugins. Also supports `all`
-    /// 
+    ///   Available categories depend on the specified plugins. Also supports `all`
+    ///
     pub async fn search_start(
         &self,
         pattern: &str,
@@ -44,12 +44,12 @@ impl super::Api {
     }
 
     /// Stop search
-    /// 
+    ///
     /// [official documentation](https://github.com/qbittorrent/qBittorrent/wiki/WebUI-API-(qBittorrent-5.0)#start-search)
     ///
     /// # Arguments
     /// * `id` - ID of the search job
-    /// 
+    ///
     pub async fn search_stop(&self, id: u64) -> Result<(), Error> {
         let mut form = multipart::Form::new();
         form = form.text("id", id.to_string());
@@ -64,13 +64,13 @@ impl super::Api {
     }
 
     /// Get search status
-    /// 
+    ///
     /// [official documentation](https://github.com/qbittorrent/qBittorrent/wiki/WebUI-API-(qBittorrent-5.0)#get-search-status)
     ///
     /// # Arguments
     ///
     /// * `id` - ID of the search job. If `None`, all search jobs are returned
-    /// 
+    ///
     pub async fn search_status(&self, id: Option<u64>) -> Result<Vec<Search>, Error> {
         let mut query = vec![];
         if let Some(id) = id {
@@ -92,7 +92,7 @@ impl super::Api {
     /// Get search results
     ///
     /// This function retrieves search results for a given search job.
-    /// 
+    ///
     /// [official documentation](https://github.com/qbittorrent/qBittorrent/wiki/WebUI-API-(qBittorrent-5.0)#get-search-results)
     ///
     /// # Arguments
@@ -100,7 +100,7 @@ impl super::Api {
     /// * `id` - The unique identifier of the search job.
     /// * `limit` - The maximum number of results to return. A value of `0` indicates no limit.
     /// * `offset` - The starting point for results. If negative, counts backwards (e.g., `-2` retrieves the 2 most recent results).
-    /// 
+    ///
     pub async fn search_results(
         &self,
         id: u64,
@@ -127,12 +127,12 @@ impl super::Api {
     }
 
     /// Delete search
-    /// 
+    ///
     /// [official documentation](https://github.com/qbittorrent/qBittorrent/wiki/WebUI-API-(qBittorrent-5.0)#delete-search)
     ///
     /// # Arguments
     /// * `id` - The unique identifier of the search job.
-    /// 
+    ///
     pub async fn search_delete(&self, id: u64) -> Result<(), Error> {
         let mut form = multipart::Form::new();
         form = form.text("id", id.to_string());
@@ -147,9 +147,9 @@ impl super::Api {
     }
 
     /// Get search plugins
-    /// 
+    ///
     /// [official documentation](https://github.com/qbittorrent/qBittorrent/wiki/WebUI-API-(qBittorrent-5.0)#get-search-plugins)
-    /// 
+    ///
     pub async fn search_plugins(&self) -> Result<Vec<SearchPlugin>, Error> {
         let plugins = self
             ._get("search/plugins")
@@ -163,12 +163,12 @@ impl super::Api {
     }
 
     /// Install search plugin
-    /// 
+    ///
     /// [official documentation](https://github.com/qbittorrent/qBittorrent/wiki/WebUI-API-(qBittorrent-5.0)#install-search-plugin)
     ///
     /// # Arguments
     /// * `sources` - List of Url and file path of the plugin to install.
-    /// 
+    ///
     pub async fn search_install_plugin(&self, sources: Vec<&str>) -> Result<(), Error> {
         let mut form = multipart::Form::new();
         form = form.text("sources", sources.join("|"));
@@ -183,12 +183,12 @@ impl super::Api {
     }
 
     /// Uninstall search plugin
-    /// 
+    ///
     /// [official documentation](https://github.com/qbittorrent/qBittorrent/wiki/WebUI-API-(qBittorrent-5.0)#uninstall-search-plugin)
     ///
     /// # Arguments
     /// * `names` - List of names for torrents to uninstall.
-    /// 
+    ///
     pub async fn search_uninstall_plugin(&self, names: Vec<&str>) -> Result<(), Error> {
         let mut form = multipart::Form::new();
         form = form.text("names", names.join("|"));
@@ -203,12 +203,12 @@ impl super::Api {
     }
 
     /// Enable search plugin
-    /// 
+    ///
     /// [official documentation](https://github.com/qbittorrent/qBittorrent/wiki/WebUI-API-(qBittorrent-5.0)#enable-search-plugin)
     ///
     /// # Arguments
     /// * `names` - List of names for torrents to enable.
-    /// 
+    ///
     pub async fn search_enable_plugin(&self, names: Vec<&str>, enable: bool) -> Result<(), Error> {
         let mut form = multipart::Form::new();
         form = form.text("names", names.join("|"));
@@ -224,9 +224,9 @@ impl super::Api {
     }
 
     /// Update search plugins
-    /// 
+    ///
     /// [official documentation](https://github.com/qbittorrent/qBittorrent/wiki/WebUI-API-(qBittorrent-5.0)#update-search-plugins)
-    /// 
+    ///
     pub async fn search_update_plugin(&self) -> Result<(), Error> {
         self._post("search/updatePlugins").await?.send().await?;
 

--- a/src/client/torrent.rs
+++ b/src/client/torrent.rs
@@ -14,11 +14,11 @@ impl super::Api {
     /// Get torrent list
     ///
     /// [official documentation](https://github.com/qbittorrent/qBittorrent/wiki/WebUI-API-(qBittorrent-5.0)#get-torrent-list)
-    /// 
+    ///
     /// # Arguments
     ///
     /// * `parames` - Parameter object
-    /// 
+    ///
     pub async fn torrents(&self, parames: TorrentListParams) -> Result<Vec<TorrentInfo>, Error> {
         let mut query = vec![];
         query.push(("reverse", parames.reverse.to_string()));
@@ -63,10 +63,9 @@ impl super::Api {
     /// # Arguments
     ///
     /// * `hash` - The hash of the torrent you want to get the generic properties of.
-    /// 
+    ///
     pub async fn torrent(&self, hash: &str) -> Result<TorrentProperties, Error> {
-        let mut query = vec![];
-        query.push(("hash", hash));
+        let query = vec![("hash", hash)];
 
         let torrent = self
             ._get("torrents/properties")
@@ -87,10 +86,9 @@ impl super::Api {
     /// # Arguments
     ///
     /// * `hash` - The hash of the torrent you want to get the trackers of.
-    /// 
+    ///
     pub async fn trackers(&self, hash: &str) -> Result<Vec<Tracker>, Error> {
-        let mut query = vec![];
-        query.push(("hash", hash));
+        let query = vec![("hash", hash)];
 
         let trackers = self
             ._get("torrents/trackers")
@@ -111,10 +109,9 @@ impl super::Api {
     /// # Arguments
     ///
     /// * `hash` - The hash of the torrent you want to get the webseeds of.
-    /// 
+    ///
     pub async fn webseeds(&self, hash: &str) -> Result<Vec<WebSeed>, Error> {
-        let mut query = vec![];
-        query.push(("hash", hash));
+        let query = vec![("hash", hash)];
 
         let webseeds = self
             ._get("torrents/webseeds")
@@ -136,8 +133,8 @@ impl super::Api {
     ///
     /// * `hash` - The hash of the torrent you want to get the files of.
     /// * `indexes` - The indexes of the files you want to retrieve. If `None`
-    /// all files will be selected.
-    /// 
+    ///   all files will be selected.
+    ///
     pub async fn files(
         &self,
         hash: &str,
@@ -175,10 +172,9 @@ impl super::Api {
     /// # Arguments
     ///
     /// * `hash` - The hash of the torrent you want to get the piece states of.
-    /// 
+    ///
     pub async fn pieces_states(&self, hash: &str) -> Result<Vec<PiecesState>, Error> {
-        let mut query = vec![];
-        query.push(("hash", hash));
+        let query = vec![("hash", hash)];
 
         let pieces = self
             ._get("torrents/pieceStates")
@@ -199,10 +195,9 @@ impl super::Api {
     /// # Arguments
     ///
     /// * `hash` - The hash of the torrent you want to get the pieces hashes of.
-    /// 
+    ///
     pub async fn pieces_hashes(&self, hash: &str) -> Result<Vec<String>, Error> {
-        let mut query = vec![];
-        query.push(("hash", hash));
+        let query = vec![("hash", hash)];
 
         let pieces = self
             ._get("torrents/pieceHashes")
@@ -223,10 +218,9 @@ impl super::Api {
     /// # Arguments
     ///
     /// * `hashes` - Hashes list of torrents to stop.
-    /// 
+    ///
     pub async fn stop(&self, hashes: Vec<&str>) -> Result<(), Error> {
-        let mut query = vec![];
-        query.push(("hashes", hashes.join("|")));
+        let query = vec![("hashes", hashes.join("|"))];
 
         self._get("torrents/stop")
             .await?
@@ -244,10 +238,9 @@ impl super::Api {
     /// # Arguments
     ///
     /// * `hashes` - Hashes list of torrents to start.
-    /// 
+    ///
     pub async fn start(&self, hashes: Vec<&str>) -> Result<(), Error> {
-        let mut query = vec![];
-        query.push(("hashes", hashes.join("|")));
+        let query = vec![("hashes", hashes.join("|"))];
 
         self._get("torrents/start")
             .await?
@@ -266,12 +259,13 @@ impl super::Api {
     ///
     /// * `hashes` - Hashes list of torrents to delete.
     /// * `delete_files` - If set to `true`, the downloaded data will also be deleted,
-    /// otherwise has no effect.
-    /// 
+    ///   otherwise has no effect.
+    ///
     pub async fn delete(&self, hashes: Vec<&str>, delete_files: bool) -> Result<(), Error> {
-        let mut query = vec![];
-        query.push(("hashes", hashes.join("|")));
-        query.push(("deleteFiles", delete_files.to_string()));
+        let query = vec![
+            ("hashes", hashes.join("|")),
+            ("deleteFiles", delete_files.to_string()),
+        ];
 
         self._get("torrents/delete")
             .await?
@@ -289,10 +283,9 @@ impl super::Api {
     /// # Arguments
     ///
     /// * `hashes` - Hashes list of torrents to recheck.
-    /// 
+    ///
     pub async fn recheck(&self, hashes: Vec<&str>) -> Result<(), Error> {
-        let mut query = vec![];
-        query.push(("hashes", hashes.join("|")));
+        let query = vec![("hashes", hashes.join("|"))];
 
         self._get("torrents/recheck")
             .await?
@@ -310,10 +303,9 @@ impl super::Api {
     /// # Arguments
     ///
     /// * `hashes` - Hashes list of torrents to reannounce.
-    /// 
+    ///
     pub async fn reannounce(&self, hashes: Vec<&str>) -> Result<(), Error> {
-        let mut query = vec![];
-        query.push(("hashes", hashes.join("|")));
+        let query = vec![("hashes", hashes.join("|"))];
 
         self._get("torrents/reannounce")
             .await?
@@ -331,7 +323,7 @@ impl super::Api {
     /// # Arguments
     ///
     /// * `params` - Torrent parameters
-    /// 
+    ///
     pub async fn add_torrent(&self, params: TorrentAddUrls) -> Result<(), Error> {
         let mut form = multipart::Form::new();
         form = form.text("urls", params.urls.join("\n"));
@@ -388,7 +380,7 @@ impl super::Api {
     ///
     /// * `hash` - Torrent hash.
     /// * `urls` - Trackers urls to add.
-    /// 
+    ///
     pub async fn add_trackers_to_torrent(&self, hash: &str, urls: Vec<&str>) -> Result<(), Error> {
         let mut form = multipart::Form::new();
         form = form.text("hash", hash.to_string());
@@ -412,7 +404,7 @@ impl super::Api {
     /// * `hash` - The hash of the torrent.
     /// * `orig_url` - The tracker URL you want to edit.
     /// * `new_url` - The new URL to replace the `orig_url`.
-    /// 
+    ///
     pub async fn edit_tracker_for_torrent(
         &self,
         hash: &str,
@@ -441,7 +433,7 @@ impl super::Api {
     ///
     /// * `hash` - Torrent hash.
     /// * `urls` - Trackers urls to remove.
-    /// 
+    ///
     pub async fn remove_trackers_from_torrent(
         &self,
         hash: &str,
@@ -468,7 +460,7 @@ impl super::Api {
     ///
     /// * `hashes` - Torrent hash.
     /// * `peers` - The peer to add. Each peer is a colon-separated `host:port`.
-    /// 
+    ///
     pub async fn add_peers(&self, hashes: Vec<&str>, peers: Vec<&str>) -> Result<(), Error> {
         let mut form = multipart::Form::new();
         form = form.text("hashes", hashes.join("|"));
@@ -490,8 +482,8 @@ impl super::Api {
     /// # Arguments
     ///
     /// * `hashes` - The hashes of the torrents you want to increase the priority of.
-    /// If `None` all torrents are selected.
-    /// 
+    ///   If `None` all torrents are selected.
+    ///
     pub async fn increase_priority(&self, hashes: Option<Vec<&str>>) -> Result<(), Error> {
         let mut form = multipart::Form::new();
         if let Some(hashes) = hashes {
@@ -516,8 +508,8 @@ impl super::Api {
     /// # Arguments
     ///
     /// * `hashes` - The hashes of the torrents you want to decrease the priority of.
-    /// If `None` all torrents are selected.
-    /// 
+    ///   If `None` all torrents are selected.
+    ///
     pub async fn decrease_priority(&self, hashes: Option<Vec<&str>>) -> Result<(), Error> {
         let mut form = multipart::Form::new();
         if let Some(hashes) = hashes {
@@ -542,8 +534,8 @@ impl super::Api {
     /// # Arguments
     ///
     /// * `hashes` - The hashes of the torrents you want to max the priority of.
-    /// If `None` all torrents are selected.
-    /// 
+    ///   If `None` all torrents are selected.
+    ///
     pub async fn max_priority(&self, hashes: Option<Vec<&str>>) -> Result<(), Error> {
         let mut form = multipart::Form::new();
         if let Some(hashes) = hashes {
@@ -568,8 +560,8 @@ impl super::Api {
     /// # Arguments
     ///
     /// * `hashes` - The hashes of the torrents you want to min the priority of.
-    /// If `None` all torrents are selected.
-    /// 
+    ///   If `None` all torrents are selected.
+    ///
     pub async fn min_priority(&self, hashes: Option<Vec<&str>>) -> Result<(), Error> {
         let mut form = multipart::Form::new();
         if let Some(hashes) = hashes {
@@ -596,7 +588,7 @@ impl super::Api {
     /// * `hash` - The hash of the torrent.
     /// * `file_ids` - File ids.
     /// * `priority` - File priority to set.
-    /// 
+    ///
     pub async fn set_file_priority(
         &self,
         hash: &str,
@@ -631,8 +623,8 @@ impl super::Api {
     /// # Arguments
     ///
     /// * `hashes` - The hashes of the torrents you want to get the download limit of.
-    /// If `None` all torrents are selected.
-    /// 
+    ///   If `None` all torrents are selected.
+    ///
     pub async fn download_limit(
         &self,
         hashes: Option<Vec<&str>>,
@@ -663,9 +655,9 @@ impl super::Api {
     /// # Arguments
     ///
     /// * `hashes` - The hashes of the torrents you want to set the download limit of.
-    /// If `None` all torrents are selected.
+    ///   If `None` all torrents are selected.
     /// * `limit` - Download limit
-    /// 
+    ///
     pub async fn set_download_limit(
         &self,
         hashes: Option<Vec<&str>>,
@@ -695,15 +687,15 @@ impl super::Api {
     /// # Arguments
     ///
     /// * `hashes` - The hashes of the torrents you want to set the share limit of.
-    /// If `None` all torrents are selected.
+    ///   If `None` all torrents are selected.
     /// * `ratio_limit` - The maximum seeding ratio for the torrent. `-2` means
-    /// the global limit should be used, `-1` means no limit.
+    ///   the global limit should be used, `-1` means no limit.
     /// * `seeding_time_limit` - The maximum seeding time (minutes) for the torrent.
-    /// `-2` means the global limit should be used, `-1` means no limit.
+    ///   `-2` means the global limit should be used, `-1` means no limit.
     /// * `inactive_seeding_time_limit` - The maximum amount of time (minutes) the
-    /// torrent is allowed to seed while being inactive. `-2` means the global limit
-    /// should be used, `-1` means no limit.
-    /// 
+    ///   torrent is allowed to seed while being inactive. `-2` means the global limit
+    ///   should be used, `-1` means no limit.
+    ///
     pub async fn set_share_limit(
         &self,
         hashes: Option<Vec<&str>>,
@@ -740,8 +732,8 @@ impl super::Api {
     /// # Arguments
     ///
     /// * `hashes` - The hashes of the torrents you want the upload limit of.
-    /// If `None` all torrents are selected.
-    /// 
+    ///   If `None` all torrents are selected.
+    ///
     pub async fn upload_limit(
         &self,
         hashes: Option<Vec<&str>>,
@@ -772,9 +764,9 @@ impl super::Api {
     /// # Arguments
     ///
     /// * `hashes` - The hashes of the torrents you want to set the upload limit of.
-    /// If `None` all torrents are selected.
+    ///   If `None` all torrents are selected.
     /// * `limit` - Upload limit
-    /// 
+    ///
     pub async fn set_upload_limit(
         &self,
         hashes: Option<Vec<&str>>,
@@ -804,9 +796,9 @@ impl super::Api {
     /// # Arguments
     ///
     /// * `hashes` - The hashes of the torrents you want to set the location of.
-    /// If `None` all torrents are selected.
+    ///   If `None` all torrents are selected.
     /// * `location` - Location to download the torrent to.
-    /// 
+    ///
     pub async fn set_location(
         &self,
         hashes: Option<Vec<&str>>,
@@ -837,7 +829,7 @@ impl super::Api {
     ///
     /// * `hash` - The hash of the torrent you want to set the name of.
     /// * `name` - Location to download the torrent to.
-    /// 
+    ///
     pub async fn set_name(&self, hash: &str, name: &str) -> Result<(), Error> {
         let mut form = multipart::Form::new();
         form = form.text("hash", hash.to_string());
@@ -859,9 +851,9 @@ impl super::Api {
     /// # Arguments
     ///
     /// * `hashes` - The hashes of the torrents you want to set the category of.
-    /// If `None` all torrents are selected.
+    ///   If `None` all torrents are selected.
     /// * `category` - Name of the category you want to set.
-    /// 
+    ///
     pub async fn set_category(
         &self,
         hashes: Option<Vec<&str>>,
@@ -887,7 +879,7 @@ impl super::Api {
     /// Get all categories
     ///
     /// [official documentation](https://github.com/qbittorrent/qBittorrent/wiki/WebUI-API-(qBittorrent-5.0)#get-all-categories)
-    /// 
+    ///
     pub async fn categories(&self) -> Result<Vec<String>, Error> {
         let categories = self
             ._get("torrents/categories")
@@ -908,7 +900,7 @@ impl super::Api {
     ///
     /// * `category` - Name for the category to create.
     /// * `save_path` - Path to download torrents for the category.
-    /// 
+    ///
     pub async fn create_category(&self, category: &str, save_path: &str) -> Result<(), Error> {
         let mut form = multipart::Form::new();
         form = form.text("category", category.to_string());
@@ -931,7 +923,7 @@ impl super::Api {
     ///
     /// * `category` - Name for the category to edit.
     /// * `save_path` - Path to download torrents for the category.
-    /// 
+    ///
     pub async fn edit_category(&self, category: &str, save_path: &str) -> Result<(), Error> {
         let mut form = multipart::Form::new();
         form = form.text("category", category.to_string());
@@ -953,7 +945,7 @@ impl super::Api {
     /// # Arguments
     ///
     /// * `categories` - List of category names to remove.
-    /// 
+    ///
     pub async fn remove_categories(&self, categories: Vec<&str>) -> Result<(), Error> {
         let mut form = multipart::Form::new();
         form = form.text("categories", categories.join("\n"));
@@ -974,9 +966,9 @@ impl super::Api {
     /// # Arguments
     ///
     /// * `hashes` - The hashes of the torrents you want to set the tags of.
-    /// If `None` all torrents are selected.
+    ///   If `None` all torrents are selected.
     /// * `tags` - List of names for the tags you want to set.
-    /// 
+    ///
     pub async fn add_tags(&self, hashes: Option<Vec<&str>>, tags: Vec<&str>) -> Result<(), Error> {
         let mut form = multipart::Form::new();
         if let Some(hashes) = hashes {
@@ -1002,9 +994,9 @@ impl super::Api {
     /// # Arguments
     ///
     /// * `hashes` - The hashes of the torrents you want to remove the tags of.
-    /// If `None` all torrents are selected.
+    ///   If `None` all torrents are selected.
     /// * `tags` - List of names for the tags you want to remove.
-    /// 
+    ///
     pub async fn remove_tags(
         &self,
         hashes: Option<Vec<&str>>,
@@ -1030,7 +1022,7 @@ impl super::Api {
     /// Get all tags
     ///
     /// [official documentation](https://github.com/qbittorrent/qBittorrent/wiki/WebUI-API-(qBittorrent-5.0)#get-all-tags)
-    /// 
+    ///
     pub async fn tags(&self) -> Result<Vec<String>, Error> {
         let tags = self
             ._get("torrents/tags")
@@ -1050,7 +1042,7 @@ impl super::Api {
     /// # Arguments
     ///
     /// * `tags` - List of tags to create.
-    /// 
+    ///
     pub async fn create_tags(&self, tags: Vec<&str>) -> Result<(), Error> {
         let mut form = multipart::Form::new();
         form = form.text("tags", tags.join(","));
@@ -1071,7 +1063,7 @@ impl super::Api {
     /// # Arguments
     ///
     /// * `tags` - List of tags to delete.
-    /// 
+    ///
     pub async fn torrent_delete_tags(&self, tags: Vec<&str>) -> Result<(), Error> {
         let mut form = multipart::Form::new();
         form = form.text("tags", tags.join(","));
@@ -1092,9 +1084,9 @@ impl super::Api {
     /// # Arguments
     ///
     /// * `hashes` - The hashes of the torrents you want to set automatic torrent management of.
-    /// If `None` all torrents are selected.
+    ///   If `None` all torrents are selected.
     /// * `enable`
-    /// 
+    ///
     pub async fn set_automatic_torrent_management(
         &self,
         hashes: Option<Vec<&str>>,
@@ -1124,8 +1116,8 @@ impl super::Api {
     /// # Arguments
     ///
     /// * `hashes` - The hashes of the torrents you want to toggle sequential download for.
-    /// If `None` all torrents are selected.
-    /// 
+    ///   If `None` all torrents are selected.
+    ///
     pub async fn toggle_sequential_download(&self, hashes: Option<Vec<&str>>) -> Result<(), Error> {
         let mut form = multipart::Form::new();
         if let Some(hashes) = hashes {
@@ -1150,8 +1142,8 @@ impl super::Api {
     /// # Arguments
     ///
     /// * `hashes` - The hashes of the torrents you want to toggle first/last piece priority for.
-    /// If `None` all torrents are selected.
-    /// 
+    ///   If `None` all torrents are selected.
+    ///
     pub async fn toggle_first_last_priority(&self, hashes: Option<Vec<&str>>) -> Result<(), Error> {
         let mut form = multipart::Form::new();
         if let Some(hashes) = hashes {
@@ -1176,9 +1168,9 @@ impl super::Api {
     /// # Arguments
     ///
     /// * `hashes` - The hashes of the torrents you want to set force start of.
-    /// If `None` all torrents are selected.
+    ///   If `None` all torrents are selected.
     /// * `enable`
-    /// 
+    ///
     pub async fn set_force_start(
         &self,
         hashes: Option<Vec<&str>>,
@@ -1208,9 +1200,9 @@ impl super::Api {
     /// # Arguments
     ///
     /// * `hashes` - The hashes of the torrents you want to set super seeding of.
-    /// If `None` all torrents are selected.
+    ///   If `None` all torrents are selected.
     /// * `enable`
-    /// 
+    ///
     pub async fn set_super_seeding(
         &self,
         hashes: Option<Vec<&str>>,
@@ -1242,7 +1234,7 @@ impl super::Api {
     /// * `hash` - The hash of the torrent
     /// * `oldPath` - The old path of the torrent
     /// * `newPath` - The new path to use for the file
-    /// 
+    ///
     pub async fn rename_file(
         &self,
         hash: &str,
@@ -1272,7 +1264,7 @@ impl super::Api {
     /// * `hash` - The hash of the torrent
     /// * `oldPath` - The old path of the torrent
     /// * `newPath` - The new path to use for the file
-    /// 
+    ///
     pub async fn torrent_rename_folder(
         &self,
         hash: &str,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,8 @@ pub mod models;
 /// Parameter objects.
 pub mod parameters;
 
+use std::fmt::Display;
+
 pub use client::Api;
 pub use error::Error;
 
@@ -95,8 +97,8 @@ impl Credentials {
     }
 }
 
-impl ToString for Credentials {
-    fn to_string(&self) -> String {
-        format!("username={}&password={}", self.username, self.password)
+impl Display for Credentials {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "username={}&password={}", self.username, self.password)
     }
 }

--- a/src/parameters.rs
+++ b/src/parameters.rs
@@ -1,5 +1,7 @@
+use std::fmt::Display;
+
 /// Torrent List/info parameter object
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct TorrentListParams {
     /// Filter torrent list by state. Allowed state filters: TorrentState
     pub filter: Option<TorrentState>,
@@ -19,21 +21,6 @@ pub struct TorrentListParams {
     pub hashes: Option<Vec<String>>,
 }
 
-impl TorrentListParams {
-    pub fn default() -> Self {
-        Self {
-            filter: None,
-            category: None,
-            tag: None,
-            sort: None,
-            reverse: false,
-            limit: None,
-            offset: None,
-            hashes: None,
-        }
-    }
-}
-
 /// Posibel Torrent states
 #[derive(Debug)]
 pub enum TorrentState {
@@ -51,22 +38,26 @@ pub enum TorrentState {
     Errored,
 }
 
-impl ToString for TorrentState {
-    fn to_string(&self) -> String {
-        match self {
-            Self::All => String::from("all"),
-            Self::Downloading => String::from("downloading"),
-            Self::Seeding => String::from("seeding"),
-            Self::Completed => String::from("completed"),
-            Self::Stopped => String::from("stopped"),
-            Self::Active => String::from("active"),
-            Self::Inactive => String::from("inactive"),
-            Self::Running => String::from("running"),
-            Self::Stalled => String::from("stalled"),
-            Self::StalledUploading => String::from("stalled_uploading"),
-            Self::StalledDownloading => String::from("stalled_downloading"),
-            Self::Errored => String::from("errored"),
-        }
+impl Display for TorrentState {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "{}",
+            match self {
+                Self::All => String::from("all"),
+                Self::Downloading => String::from("downloading"),
+                Self::Seeding => String::from("seeding"),
+                Self::Completed => String::from("completed"),
+                Self::Stopped => String::from("stopped"),
+                Self::Active => String::from("active"),
+                Self::Inactive => String::from("inactive"),
+                Self::Running => String::from("running"),
+                Self::Stalled => String::from("stalled"),
+                Self::StalledUploading => String::from("stalled_uploading"),
+                Self::StalledDownloading => String::from("stalled_downloading"),
+                Self::Errored => String::from("errored"),
+            }
+        )
     }
 }
 
@@ -168,62 +159,66 @@ pub enum TorrentSort {
     Upspeed,
 }
 
-impl ToString for TorrentSort {
-    fn to_string(&self) -> String {
-        match self {
-            Self::AddedOn => String::from("added_on"),
-            Self::AmountLeft => String::from("amount_left"),
-            Self::AutoTmm => String::from("auto_tmm"),
-            Self::Availability => String::from("availability"),
-            Self::Category => String::from("category"),
-            Self::Completed => String::from("completed"),
-            Self::CompletionOn => String::from("completion_on"),
-            Self::ContentPath => String::from("content_path"),
-            Self::DlLimit => String::from("dl_limit"),
-            Self::Dlspeed => String::from("dlspeed"),
-            Self::Downloaded => String::from("downloaded"),
-            Self::DownloadedSession => String::from("downloaded_session"),
-            Self::Eta => String::from("eta"),
-            Self::FLPiecePrio => String::from("f_l_piece_prio"),
-            Self::ForceStart => String::from("force_start"),
-            Self::Hash => String::from("hash"),
-            Self::Private => String::from("private"),
-            Self::LastActivity => String::from("last_activity"),
-            Self::MagnetUri => String::from("magnet_uri"),
-            Self::MaxRatio => String::from("max_ratio"),
-            Self::MaxSeedingTime => String::from("max_seeding_time"),
-            Self::Name => String::from("name"),
-            Self::NumComplete => String::from("num_complete"),
-            Self::NumIncomplete => String::from("num_incomplete"),
-            Self::NumLeechs => String::from("num_leechs"),
-            Self::NumSeeds => String::from("num_seeds"),
-            Self::Priority => String::from("priority"),
-            Self::Progress => String::from("progress"),
-            Self::Ratio => String::from("ratio"),
-            Self::RatioLimit => String::from("ratio_limit"),
-            Self::Reannounce => String::from("reannounce"),
-            Self::SavePath => String::from("save_path"),
-            Self::SeedingTime => String::from("seeding_time"),
-            Self::SeedingTimeLimit => String::from("seeding_time_limit"),
-            Self::SeenComplete => String::from("seen_complete"),
-            Self::SeqDl => String::from("seq_dl"),
-            Self::Size => String::from("size"),
-            Self::State => String::from("state"),
-            Self::SuperSeeding => String::from("super_seeding"),
-            Self::Tags => String::from("tags"),
-            Self::TimeActive => String::from("time_active"),
-            Self::TotalSize => String::from("total_size"),
-            Self::Tracker => String::from("tracker"),
-            Self::UpLimit => String::from("up_limit"),
-            Self::Uploaded => String::from("uploaded"),
-            Self::UploadedSession => String::from("uploaded_session"),
-            Self::Upspeed => String::from("upspeed"),
-        }
+impl Display for TorrentSort {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "{}",
+            match self {
+                Self::AddedOn => String::from("added_on"),
+                Self::AmountLeft => String::from("amount_left"),
+                Self::AutoTmm => String::from("auto_tmm"),
+                Self::Availability => String::from("availability"),
+                Self::Category => String::from("category"),
+                Self::Completed => String::from("completed"),
+                Self::CompletionOn => String::from("completion_on"),
+                Self::ContentPath => String::from("content_path"),
+                Self::DlLimit => String::from("dl_limit"),
+                Self::Dlspeed => String::from("dlspeed"),
+                Self::Downloaded => String::from("downloaded"),
+                Self::DownloadedSession => String::from("downloaded_session"),
+                Self::Eta => String::from("eta"),
+                Self::FLPiecePrio => String::from("f_l_piece_prio"),
+                Self::ForceStart => String::from("force_start"),
+                Self::Hash => String::from("hash"),
+                Self::Private => String::from("private"),
+                Self::LastActivity => String::from("last_activity"),
+                Self::MagnetUri => String::from("magnet_uri"),
+                Self::MaxRatio => String::from("max_ratio"),
+                Self::MaxSeedingTime => String::from("max_seeding_time"),
+                Self::Name => String::from("name"),
+                Self::NumComplete => String::from("num_complete"),
+                Self::NumIncomplete => String::from("num_incomplete"),
+                Self::NumLeechs => String::from("num_leechs"),
+                Self::NumSeeds => String::from("num_seeds"),
+                Self::Priority => String::from("priority"),
+                Self::Progress => String::from("progress"),
+                Self::Ratio => String::from("ratio"),
+                Self::RatioLimit => String::from("ratio_limit"),
+                Self::Reannounce => String::from("reannounce"),
+                Self::SavePath => String::from("save_path"),
+                Self::SeedingTime => String::from("seeding_time"),
+                Self::SeedingTimeLimit => String::from("seeding_time_limit"),
+                Self::SeenComplete => String::from("seen_complete"),
+                Self::SeqDl => String::from("seq_dl"),
+                Self::Size => String::from("size"),
+                Self::State => String::from("state"),
+                Self::SuperSeeding => String::from("super_seeding"),
+                Self::Tags => String::from("tags"),
+                Self::TimeActive => String::from("time_active"),
+                Self::TotalSize => String::from("total_size"),
+                Self::Tracker => String::from("tracker"),
+                Self::UpLimit => String::from("up_limit"),
+                Self::Uploaded => String::from("uploaded"),
+                Self::UploadedSession => String::from("uploaded_session"),
+                Self::Upspeed => String::from("upspeed"),
+            }
+        )
     }
 }
 
 /// Add torrent parameter object
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct TorrentAddUrls {
     /// Torrent URLs separated with newlines
     pub urls: Vec<String>,
@@ -259,7 +254,7 @@ pub struct TorrentAddUrls {
 }
 
 impl TorrentAddUrls {
-    pub fn default(urls: Vec<String>) -> Self {
+    pub fn new(urls: Vec<String>) -> Self {
         Self {
             urls,
             savepath: None,


### PR DESCRIPTION
Clippy got annoyed, so here are the fixes.

One thing that clippy didn't get annoyed about is:
```rust
impl TorrentAddUrls {
    pub fn default(urls: Vec<String>) -> Self {
		// ...
	}
}
```
However, i changed it to:
```rust
impl TorrentAddUrls {
    pub fn new(urls: Vec<String>) -> Self {
		// ...
	}
}
```
Because this API call makes more sense to me

Other than that, it's either clippy or auto editor formatting.