### PR TITLE
Github based testing

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -1,0 +1,18 @@
+on:
+  push:
+  pull_request:
+
+jobs:
+  Run_tests:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Install qbittorrent-nox
+        run: sudo apt install qbittorrent-nox
+
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Run tests
+        run: |
+          cargo test

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -13,6 +13,12 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Setup rust
+        uses: actions-rust-lang/setup-rust-toolchain@v1
+
+      - name: Start qbittorrent-nox in background
+        run: qbittorrent-nox &
+
       - name: Run tests
         run: |
           cargo test

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -6,6 +6,15 @@ jobs:
   Run_tests:
     runs-on: ubuntu-latest
 
+    env:
+      # url should not need to chance as we are running qbittorrent locally on github servers.
+      url: http://localhost
+      port: 45378
+      username: admin
+
+      password: "@ByteArray(ARQ77eY1NUZaQsuDHbIMCA==:0WMRkYTUWVT9wVvdDtHAjU9b3b7uB8NR1Gur2hmQCvCDpm39Q+PsJRJPaCU51dEiz+dTzh8qbPsL8WkFljQYFQ==)"
+      unencrypted_password: adminadmin
+
     steps:
       - name: Install qbittorrent-nox
         # Source: https://github.com/userdocs/qbittorrent-nox-static
@@ -19,8 +28,9 @@ jobs:
           mkdir -p ~/.config/qBittorrent
           cat > ~/.config/qBittorrent/qBittorrent.conf << 'EOF'
           [Preferences]
-          WebUI\Password_PBKDF2="@ByteArray(ARQ77eY1NUZaQsuDHbIMCA==:0WMRkYTUWVT9wVvdDtHAjU9b3b7uB8NR1Gur2hmQCvCDpm39Q+PsJRJPaCU51dEiz+dTzh8qbPsL8WkFljQYFQ==)"
-          WebUI\Port=45378
+          WebUI\Password_PBKDF2="${{ env.password }}"
+          WebUI\Port=${{ env.port }}
+          WebUI\Username=${{ env.username }}
           EOF
 
       - name: Debug version
@@ -28,6 +38,15 @@ jobs:
 
       - name: Checkout
         uses: actions/checkout@v4
+
+      - name: Setup dotenv
+        run: |
+          cat > .env << 'EOF'
+          url = ${{ env.url }}
+          port = ${{ env.port }}
+          username = ${{ env.username }}
+          password = ${{ env.unencrypted_password }}
+          EOF
 
       - name: Setup rust
         uses: actions-rust-lang/setup-rust-toolchain@v1

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -6,14 +6,15 @@ jobs:
   Run_tests:
     runs-on: ubuntu-latest
 
+    # The way github works, means that this `env` will also pretty much do the `.env` file for rust to work.
     env:
       # url should not need to chance as we are running qbittorrent locally on github servers.
       url: http://localhost
       port: 45378
-      username: admin
+      username: dragon
 
-      password: "@ByteArray(ARQ77eY1NUZaQsuDHbIMCA==:0WMRkYTUWVT9wVvdDtHAjU9b3b7uB8NR1Gur2hmQCvCDpm39Q+PsJRJPaCU51dEiz+dTzh8qbPsL8WkFljQYFQ==)"
-      unencrypted_password: adminadmin
+      encrypted_password: "@ByteArray(ARQ77eY1NUZaQsuDHbIMCA==:0WMRkYTUWVT9wVvdDtHAjU9b3b7uB8NR1Gur2hmQCvCDpm39Q+PsJRJPaCU51dEiz+dTzh8qbPsL8WkFljQYFQ==)"
+      password: adminadmin
 
     steps:
       - name: Install qbittorrent-nox
@@ -28,9 +29,9 @@ jobs:
           mkdir -p ~/.config/qBittorrent
           cat > ~/.config/qBittorrent/qBittorrent.conf << 'EOF'
           [Preferences]
-          WebUI\Password_PBKDF2="${{ env.password }}"
-          WebUI\Port=${{ env.port }}
           WebUI\Username=${{ env.username }}
+          WebUI\Password_PBKDF2="${{ env.encrypted_password }}"
+          WebUI\Port=${{ env.port }}
           EOF
 
       - name: Debug version
@@ -39,19 +40,14 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Setup dotenv
+      - name: Debug files
         run: |
-          cat > .env << 'EOF'
-          url = ${{ env.url }}
-          port = ${{ env.port }}
-          username = ${{ env.username }}
-          password = ${{ env.unencrypted_password }}
-          EOF
+          cat ~/.config/qBittorrent/qBittorrent.conf
 
       - name: Setup rust
         uses: actions-rust-lang/setup-rust-toolchain@v1
 
       - name: Run tests
         run: |
-          ~/bin/qbittorrent-nox &
+          ~/bin/qbittorrent-nox --confirm-legal-notice &
           cargo test -- --include-ignored

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -9,7 +9,7 @@ jobs:
     steps:
       - name: Install qbittorrent-nox
         run: |
-          sudo add-apt-repository ppa:qbittorrent-team/qbittorrent-stable
+          sudo add-apt-repository ppa:qbittorrent-team/qbittorrent-unstable
           sudo apt update
           sudo apt install qbittorrent-nox
 

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -10,15 +10,16 @@ jobs:
       - name: Install qbittorrent-nox
         run: sudo apt install qbittorrent-nox
 
+      - name: Debug version
+        run: qbittorrent-nox -v
+
       - name: Checkout
         uses: actions/checkout@v4
 
       - name: Setup rust
         uses: actions-rust-lang/setup-rust-toolchain@v1
 
-      - name: Start qbittorrent-nox in background
-        run: qbittorrent-nox &
-
       - name: Run tests
         run: |
+          qbittorrent-nox &
           cargo test

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -35,4 +35,4 @@ jobs:
       - name: Run tests
         run: |
           ~/bin/qbittorrent-nox &
-          cargo test
+          cargo test -- --include-ignored

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -8,7 +8,10 @@ jobs:
 
     steps:
       - name: Install qbittorrent-nox
-        run: sudo apt install qbittorrent-nox
+        run: |
+          sudo add-apt-repository ppa:qbittorrent-team/qbittorrent-stable
+          sudo apt update
+          sudo apt install qbittorrent-nox
 
       - name: Debug version
         run: qbittorrent-nox -v

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -8,10 +8,11 @@ jobs:
 
     steps:
       - name: Install qbittorrent-nox
+        # Source: https://github.com/userdocs/qbittorrent-nox-static
         run: |
-          sudo add-apt-repository ppa:qbittorrent-team/qbittorrent-unstable
-          sudo apt update
-          sudo apt install qbittorrent-nox
+          mkdir -p ~/bin && source ~/.profile
+          wget -qO ~/bin/qbittorrent-nox https://github.com/userdocs/qbittorrent-nox-static/releases/latest/download/x86_64-qbittorrent-nox
+          chmod 700 ~/bin/qbittorrent-nox
 
       - name: Debug version
         run: qbittorrent-nox -v

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -11,7 +11,7 @@ jobs:
       # url should not need to chance as we are running qbittorrent locally on github servers.
       url: http://localhost
       port: 45378
-      username: dragon
+      username: admin
 
       encrypted_password: "@ByteArray(ARQ77eY1NUZaQsuDHbIMCA==:0WMRkYTUWVT9wVvdDtHAjU9b3b7uB8NR1Gur2hmQCvCDpm39Q+PsJRJPaCU51dEiz+dTzh8qbPsL8WkFljQYFQ==)"
       password: adminadmin

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -14,6 +14,14 @@ jobs:
           wget -qO ~/bin/qbittorrent-nox https://github.com/userdocs/qbittorrent-nox-static/releases/latest/download/x86_64-qbittorrent-nox
           chmod 700 ~/bin/qbittorrent-nox
 
+      - name: Configure qBittorrent
+        run: |
+          mkdir -p ~/.config/qBittorrent
+          cat > ~/.config/qBittorrent/qBittorrent.conf << 'EOF'
+          [Preferences]
+          WebUI\Password_PBKDF2="@ByteArray(ARQ77eY1NUZaQsuDHbIMCA==:0WMRkYTUWVT9wVvdDtHAjU9b3b7uB8NR1Gur2hmQCvCDpm39Q+PsJRJPaCU51dEiz+dTzh8qbPsL8WkFljQYFQ==)"
+          EOF
+
       - name: Debug version
         run: ~/bin/qbittorrent-nox -v
 

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -20,6 +20,7 @@ jobs:
           cat > ~/.config/qBittorrent/qBittorrent.conf << 'EOF'
           [Preferences]
           WebUI\Password_PBKDF2="@ByteArray(ARQ77eY1NUZaQsuDHbIMCA==:0WMRkYTUWVT9wVvdDtHAjU9b3b7uB8NR1Gur2hmQCvCDpm39Q+PsJRJPaCU51dEiz+dTzh8qbPsL8WkFljQYFQ==)"
+          WebUI\Port=45378
           EOF
 
       - name: Debug version

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -15,7 +15,7 @@ jobs:
           chmod 700 ~/bin/qbittorrent-nox
 
       - name: Debug version
-        run: qbittorrent-nox -v
+        run: ~/bin/qbittorrent-nox -v
 
       - name: Checkout
         uses: actions/checkout@v4
@@ -25,5 +25,5 @@ jobs:
 
       - name: Run tests
         run: |
-          qbittorrent-nox &
+          ~/bin/qbittorrent-nox &
           cargo test

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,10 @@
+# No need to include the compiled data
 /target
-
+# It's a library
 Cargo.lock
+
+# used in testing, should be local to device in most situtations. Github will automatically create one whilst testing.
+.env
+
+# Other
 /tests/me.rs

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,3 +17,6 @@ tokio = { version = "1.45.1", features = ["full"] }
 serde = { version = "1.0.219", features = ["derive"] }
 serde_json = "1.0.140"
 serde_repr = "0.1.20"
+
+[dev-dependencies]
+dotenv = "0.15.0"

--- a/tests/authentication/login_user_pass.rs
+++ b/tests/authentication/login_user_pass.rs
@@ -1,30 +1,6 @@
 use qbit::Api;
 
 #[tokio::test]
-async fn login_url_1() {
-    let result =
-        Api::new_login_username_password("http://localhost:45378/", "admin", "adminadmin").await;
-
-    if result.is_err() {
-        eprintln!("{:?}", result.as_ref().err().unwrap());
-    }
-
-    assert!(result.is_ok());
-}
-
-#[tokio::test]
-async fn login_url_2() {
-    let result =
-        Api::new_login_username_password("http://localhost:45378", "admin", "adminadmin").await;
-
-    if result.is_err() {
-        eprintln!("{:?}", result.as_ref().err().unwrap());
-    }
-
-    assert!(result.is_ok());
-}
-
-#[tokio::test]
 async fn incorrect_username() {
     let result =
         Api::new_login_username_password("http://localhost:45378/", "fjiooiaaso", "adminadmin")

--- a/tests/authentication/login_user_pass.rs
+++ b/tests/authentication/login_user_pass.rs
@@ -1,0 +1,34 @@
+use qbit::Api;
+
+#[tokio::test]
+async fn login_url_1() {
+    let result =
+        Api::new_login_username_password("http://127.0.0.1:8090/", "admin", "adminadmin").await;
+
+    assert!(result.is_ok());
+}
+
+#[tokio::test]
+async fn login_url_2() {
+    let result =
+        Api::new_login_username_password("http://127.0.0.1:8090", "admin", "adminadmin").await;
+
+    assert!(result.is_ok());
+}
+
+#[tokio::test]
+async fn incorrect_username() {
+    let result =
+        Api::new_login_username_password("http://127.0.0.1:8090/", "fjiooiaaso", "adminadmin")
+            .await;
+
+    assert!(result.is_err());
+}
+
+#[tokio::test]
+async fn incorrect_password() {
+    let result =
+        Api::new_login_username_password("http://127.0.0.1:8090/", "admin", "snkabjhioahsio").await;
+
+    assert!(result.is_err());
+}

--- a/tests/authentication/login_user_pass.rs
+++ b/tests/authentication/login_user_pass.rs
@@ -3,7 +3,7 @@ use qbit::Api;
 #[tokio::test]
 async fn login_url_1() {
     let result =
-        Api::new_login_username_password("http://127.0.0.1:8090/", "admin", "adminadmin").await;
+        Api::new_login_username_password("http://localhost:45378/", "admin", "adminadmin").await;
 
     if result.is_err() {
         eprintln!("{:?}", result.as_ref().err().unwrap());
@@ -15,7 +15,7 @@ async fn login_url_1() {
 #[tokio::test]
 async fn login_url_2() {
     let result =
-        Api::new_login_username_password("http://127.0.0.1:8090", "admin", "adminadmin").await;
+        Api::new_login_username_password("http://localhost:45378", "admin", "adminadmin").await;
 
     if result.is_err() {
         eprintln!("{:?}", result.as_ref().err().unwrap());
@@ -27,7 +27,7 @@ async fn login_url_2() {
 #[tokio::test]
 async fn incorrect_username() {
     let result =
-        Api::new_login_username_password("http://127.0.0.1:8090/", "fjiooiaaso", "adminadmin")
+        Api::new_login_username_password("http://localhost:45378/", "fjiooiaaso", "adminadmin")
             .await;
 
     assert!(result.is_err());
@@ -36,7 +36,8 @@ async fn incorrect_username() {
 #[tokio::test]
 async fn incorrect_password() {
     let result =
-        Api::new_login_username_password("http://127.0.0.1:8090/", "admin", "snkabjhioahsio").await;
+        Api::new_login_username_password("http://localhost:45378/", "admin", "snkabjhioahsio")
+            .await;
 
     assert!(result.is_err());
 }

--- a/tests/authentication/login_user_pass.rs
+++ b/tests/authentication/login_user_pass.rs
@@ -1,30 +1,5 @@
-use dotenv::dotenv;
+use crate::{get_server_details, get_server_password, get_server_username};
 use qbit::Api;
-use std::env;
-
-fn get_server_details() -> String {
-    dotenv().ok();
-
-    let url = env::var("url");
-    let port = env::var("port");
-
-    if url.is_err() || port.is_err() {
-        println!("Default to `http://localhost:45378` as couldn't fully load data from .env");
-        return String::from("http://localhost:45378");
-    }
-
-    let finished_url = format!("{}:{}", url.unwrap(), port.unwrap());
-    println!("Using {} from .env file", finished_url);
-    finished_url
-}
-
-fn get_server_username() -> String {
-    env::var("username").unwrap_or("admin".to_string())
-}
-
-fn get_server_password() -> String {
-    env::var("password").unwrap_or("adminadmin".to_string())
-}
 
 #[tokio::test]
 #[ignore = "Test hits api endpoint"]

--- a/tests/authentication/login_user_pass.rs
+++ b/tests/authentication/login_user_pass.rs
@@ -1,10 +1,40 @@
+use dotenv::dotenv;
 use qbit::Api;
+use std::env;
+
+fn get_server_details() -> String {
+    dotenv().ok();
+
+    let url = env::var("url");
+    let port = env::var("port");
+
+    if url.is_err() || port.is_err() {
+        println!("Default to `http://localhost:45378` as couldn't fully load data from .env");
+        return String::from("http://localhost:45378");
+    }
+
+    let finished_url = format!("{}:{}", url.unwrap(), port.unwrap());
+    println!("Using {} from .env file", finished_url);
+    finished_url
+}
+
+fn get_server_username() -> String {
+    env::var("username").unwrap_or("admin".to_string())
+}
+
+fn get_server_password() -> String {
+    env::var("password").unwrap_or("adminadmin".to_string())
+}
 
 #[tokio::test]
 #[ignore = "Test hits api endpoint"]
 async fn correct_credentials() {
-    let result =
-        Api::new_login_username_password("http://localhost:45378", "admin", "adminadmin").await;
+    let result = Api::new_login_username_password(
+        &get_server_details(),
+        &get_server_username(),
+        &get_server_password(),
+    )
+    .await;
 
     if result.is_err() {
         println!("Err: {:?}", result.err().unwrap());
@@ -17,9 +47,12 @@ async fn correct_credentials() {
 #[tokio::test]
 #[ignore = "Test hits api endpoint"]
 async fn incorrect_username() {
-    let result =
-        Api::new_login_username_password("http://localhost:45378", "fjiooiaaso", "adminadmin")
-            .await;
+    let result = Api::new_login_username_password(
+        &get_server_details(),
+        "fjiooiaaso",
+        &get_server_password(),
+    )
+    .await;
 
     assert!(result.is_err());
     assert!(matches!(result.err().unwrap(), qbit::Error::AuthFailed(_)));
@@ -28,8 +61,12 @@ async fn incorrect_username() {
 #[tokio::test]
 #[ignore = "Test hits api endpoint"]
 async fn incorrect_password() {
-    let result =
-        Api::new_login_username_password("http://localhost:45378", "admin", "snkabjhioahsio").await;
+    let result = Api::new_login_username_password(
+        &get_server_details(),
+        &get_server_username(),
+        "snkabjhioahsio",
+    )
+    .await;
 
     assert!(result.is_err());
     assert!(matches!(result.err().unwrap(), qbit::Error::AuthFailed(_)));

--- a/tests/authentication/login_user_pass.rs
+++ b/tests/authentication/login_user_pass.rs
@@ -20,6 +20,7 @@ async fn incorrect_username() {
             .await;
 
     assert!(result.is_err());
+    assert!(matches!(result.err().unwrap(), qbit::Error::AuthFailed(_)));
 }
 
 #[tokio::test]
@@ -28,4 +29,5 @@ async fn incorrect_password() {
         Api::new_login_username_password("http://localhost:45378", "admin", "snkabjhioahsio").await;
 
     assert!(result.is_err());
+    assert!(matches!(result.err().unwrap(), qbit::Error::AuthFailed(_)));
 }

--- a/tests/authentication/login_user_pass.rs
+++ b/tests/authentication/login_user_pass.rs
@@ -1,6 +1,7 @@
 use qbit::Api;
 
 #[tokio::test]
+#[ignore = "Test hits api endpoint"]
 async fn correct_credentials() {
     let result =
         Api::new_login_username_password("http://localhost:45378", "admin", "adminadmin").await;
@@ -14,6 +15,7 @@ async fn correct_credentials() {
 }
 
 #[tokio::test]
+#[ignore = "Test hits api endpoint"]
 async fn incorrect_username() {
     let result =
         Api::new_login_username_password("http://localhost:45378", "fjiooiaaso", "adminadmin")
@@ -24,6 +26,7 @@ async fn incorrect_username() {
 }
 
 #[tokio::test]
+#[ignore = "Test hits api endpoint"]
 async fn incorrect_password() {
     let result =
         Api::new_login_username_password("http://localhost:45378", "admin", "snkabjhioahsio").await;

--- a/tests/authentication/login_user_pass.rs
+++ b/tests/authentication/login_user_pass.rs
@@ -3,7 +3,7 @@ use qbit::Api;
 #[tokio::test]
 async fn correct_credentials() {
     let result =
-        Api::new_login_username_password("http://localhost:45378/", "admin", "adminadmin").await;
+        Api::new_login_username_password("http://localhost:45378", "admin", "adminadmin").await;
 
     if result.is_err() {
         println!("Err: {:?}", result.err().unwrap());
@@ -16,7 +16,7 @@ async fn correct_credentials() {
 #[tokio::test]
 async fn incorrect_username() {
     let result =
-        Api::new_login_username_password("http://localhost:45378/", "fjiooiaaso", "adminadmin")
+        Api::new_login_username_password("http://localhost:45378", "fjiooiaaso", "adminadmin")
             .await;
 
     assert!(result.is_err());
@@ -25,8 +25,7 @@ async fn incorrect_username() {
 #[tokio::test]
 async fn incorrect_password() {
     let result =
-        Api::new_login_username_password("http://localhost:45378/", "admin", "snkabjhioahsio")
-            .await;
+        Api::new_login_username_password("http://localhost:45378", "admin", "snkabjhioahsio").await;
 
     assert!(result.is_err());
 }

--- a/tests/authentication/login_user_pass.rs
+++ b/tests/authentication/login_user_pass.rs
@@ -5,6 +5,10 @@ async fn login_url_1() {
     let result =
         Api::new_login_username_password("http://127.0.0.1:8090/", "admin", "adminadmin").await;
 
+    if result.is_err() {
+        eprintln!("{:?}", result.as_ref().err().unwrap());
+    }
+
     assert!(result.is_ok());
 }
 
@@ -12,6 +16,10 @@ async fn login_url_1() {
 async fn login_url_2() {
     let result =
         Api::new_login_username_password("http://127.0.0.1:8090", "admin", "adminadmin").await;
+
+    if result.is_err() {
+        eprintln!("{:?}", result.as_ref().err().unwrap());
+    }
 
     assert!(result.is_ok());
 }

--- a/tests/authentication/login_user_pass.rs
+++ b/tests/authentication/login_user_pass.rs
@@ -1,6 +1,19 @@
 use qbit::Api;
 
 #[tokio::test]
+async fn correct_credentials() {
+    let result =
+        Api::new_login_username_password("http://localhost:45378/", "admin", "adminadmin").await;
+
+    if result.is_err() {
+        println!("Err: {:?}", result.err().unwrap());
+        assert!(false);
+    }
+
+    assert!(true);
+}
+
+#[tokio::test]
 async fn incorrect_username() {
     let result =
         Api::new_login_username_password("http://localhost:45378/", "fjiooiaaso", "adminadmin")

--- a/tests/authentication/mod.rs
+++ b/tests/authentication/mod.rs
@@ -1,0 +1,1 @@
+pub mod login_user_pass;

--- a/tests/mod.rs
+++ b/tests/mod.rs
@@ -1,0 +1,1 @@
+pub mod authentication;

--- a/tests/mod.rs
+++ b/tests/mod.rs
@@ -1,1 +1,28 @@
+use dotenv::dotenv;
+use std::env;
+
 pub mod authentication;
+
+pub fn get_server_details() -> String {
+    dotenv().ok();
+
+    let url = env::var("url");
+    let port = env::var("port");
+
+    if url.is_err() || port.is_err() {
+        println!("Default to `http://localhost:45378` as couldn't fully load data from .env");
+        return String::from("http://localhost:45378");
+    }
+
+    let finished_url = format!("{}:{}", url.unwrap(), port.unwrap());
+    println!("Using {} from .env file", finished_url);
+    finished_url
+}
+
+pub fn get_server_username() -> String {
+    env::var("username").unwrap_or("admin".to_string())
+}
+
+pub fn get_server_password() -> String {
+    env::var("password").unwrap_or("adminadmin".to_string())
+}


### PR DESCRIPTION
Related to: #7 
(This took a while to implement, but i got it working yay)

After writing the basic tests for #7, i thought to go a bit further and just get github to run the tests as well. This also setups the repo for allowing more tests in the future.

The annoying thing is install qbittorrent-nox, due to it not being in Debain-stable yet. However after finding a workaround for that, it's really simple to get running. (after like 3 different methods, see commit history)

An example of the action in action can be found here: https://github.com/dragmine149/qbittorrent-webui-api/actions/runs/16229414797/job/45828851794

The only downside is with running tests locally, as the `Port`, `username`, `password` are forced but that isn't too big of an issue imo.