### PR TITLE
fix: popularity being integer instead of float

### DIFF
--- a/src/models/torrent.rs
+++ b/src/models/torrent.rs
@@ -76,7 +76,7 @@ pub struct Torrent {
     /// Number of seeds connected to
     pub num_seeds: i64,
     /// Popularity of the torrent
-    pub popularity: i64,
+    pub popularity: f64,
     /// Torrent priority. Returns -1 if queuing is disabled or torrent is in seed mode
     pub priority: i64,
     /// True if torrent is from a private tracker (added in 5.0.0)
@@ -200,7 +200,7 @@ impl<'de> Visitor<'de> for TorrentMapVisitor {
             num_incomplete: i64,
             num_leechs: i64,
             num_seeds: i64,
-            popularity: i64,
+            popularity: f64,
             priority: i64,
             private: Option<bool>,
             progress: f32,


### PR DESCRIPTION
Some random data from qbit api
```json
{
    "added_on": 1753316205,
    "amount_left": 1018356300,
    "auto_tmm": false,
    "availability": 4.426000118255615,
    "category": "Anime",
    "comment": "",
    "completed": 452968448,
    "completion_on": -1,
    "content_path": "/home/dragmine/Downloads/[Yameii] WITCH WATCH - S01E13 [English Dub] [CR WEB-DL 1080p] [86EFAC3F].mkv",
    "dl_limit": 0,
    "dlspeed": 274079,
    "download_path": "",
    "downloaded": 452947367,
    "downloaded_session": 453014848,
    "eta": 1060,
    "f_l_piece_prio": false,
    "force_start": false,
    "has_metadata": true,
    "hash": "ac7f22241615b45b9143052b3beb802a9a808e05",
    "inactive_seeding_time_limit": -2,
    "infohash_v1": "ac7f22241615b45b9143052b3beb802a9a808e05",
    "infohash_v2": "",
    "last_activity": 1753316310,
    "magnet_uri": "magnet:?xt=urn:btih:ac7f22241615b45b9143052b3beb802a9a808e05&dn=%5BYameii%5D%20WITCH%20WATCH%20-%20S01E13%20%5BEnglish%20Dub%5D%20%5BCR%20WEB-DL%201080p%5D%20%5B86EFAC3F%5D.mkv&xl=1471324748",
    "max_inactive_seeding_time": -1,
    "max_ratio": -1,
    "max_seeding_time": -1,
    "name": "[Yameii] WITCH WATCH - S01E13 [English Dub] [CR WEB-DL 1080p] [86EFAC3F].mkv",
    "num_complete": 7,
    "num_incomplete": 48,
    "num_leechs": 1,
    "num_seeds": 4,
    "popularity": 10.996565422348848,
    "priority": 1,
    "private": false,
    "progress": 0.30786435735260265,
    "ratio": 0.0004348871731050376,
    "ratio_limit": -2,
    "reannounce": 0,
    "root_path": "",
    "save_path": "/home/dragmine/Downloads",
    "seeding_time": 0,
    "seeding_time_limit": -2,
    "seen_complete": 1753316310,
    "seq_dl": false,
    "size": 1471324748,
    "state": "downloading",
    "super_seeding": false,
    "tags": "",
    "time_active": 104,
    "total_size": 1471324748,
    "tracker": "",
    "trackers_count": 0,
    "up_limit": 0,
    "uploaded": 196981,
    "uploaded_session": 196981,
    "upspeed": 1039
  },
```
Main point is
> ```json
> "popularity": 10.996565422348848,

And the source code relating to the issue. Showing `qreal` instead of `int` or similar
https://github.com/qbittorrent/qBittorrent/blob/master/src/base/bittorrent/torrentimpl.cpp#L1566