### PR TITLE
Option<bool> makes more sense than Option<String>

### DIFF
--- a/src/client/torrent.rs
+++ b/src/client/torrent.rs
@@ -389,7 +389,7 @@ impl super::Api {
             form = form.text("tags", tags.join(","));
         }
         if let Some(root_folder) = params.root_folder {
-            form = form.text("root_folder", root_folder);
+            form = form.text("root_folder", root_folder.to_string());
         }
         if let Some(rename) = params.rename {
             form = form.text("rename", rename);

--- a/src/parameters.rs
+++ b/src/parameters.rs
@@ -234,8 +234,8 @@ pub struct AddTorrent {
     pub skip_checking: bool,
     /// Add torrents in the paused state. Possible values are `true`, `false` (default)
     pub paused: bool,
-    /// Create the root folder. Possible values are `"true"`, `"false"`, unset (default)
-    pub root_folder: Option<String>,
+    /// Create the root folder. Possible values are `true`, `false`, unset (default)
+    pub root_folder: Option<bool>,
     /// Rename torrent
     pub rename: Option<String>,
     /// Set torrent upload speed limit. Unit in bytes/second


### PR DESCRIPTION
This PR also prevents the following from happening:
```rs
torrents.root_folder = Some(format!(
    "/home/jellyfin/media/anime/{}",
    nyaa.titles.clean_title().english
));
```
*(This was me reading the variable names and not the documentation of said variable)*

Doing `Some(true)` fells much more natural than `Some("true".to_string())` as well, so unless theres a hidden forth option i don't see the need to keep it a string especially when other values are also boolean whilst the API technically wants a string