### PR TITLE
Add option to use Builder

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ serde = { version = "1.0.219", features = ["derive"] }
 serde_json = "1.0.140"
 serde_repr = "0.1.20"
 url = "2.5.4"
+derive_builder = "0.20.2"
 
 [dev-dependencies]
 dotenv = "0.15.0"

--- a/src/parameters.rs
+++ b/src/parameters.rs
@@ -1,3 +1,4 @@
+use derive_builder::Builder;
 use std::fmt::Display;
 
 /// Torrent List/info parameter object
@@ -218,39 +219,53 @@ impl Display for TorrentSort {
 }
 
 /// Add torrent parameter object
-#[derive(Debug, Default)]
+#[derive(Debug, Default, Builder)]
 pub struct AddTorrent {
     /// A list of torrent files or magnet links to be added.
     ///
     /// This field is required and must contain at least one item.
     pub torrents: AddTorrentType,
     /// Download folder
+    #[builder(setter(into, strip_option), default)]
     pub savepath: Option<String>,
     /// Category for the torrent
+    #[builder(setter(into, strip_option), default)]
     pub category: Option<String>,
     /// Tags for the torrent, split by `,`
+    #[builder(setter(into, strip_option), default)]
     pub tags: Option<Vec<String>>,
     /// Skip hash checking. Possible values are `true`, `false` (default)
+    #[builder(default)]
     pub skip_checking: bool,
     /// Add torrents in the paused state. Possible values are `true`, `false` (default)
+    #[builder(default)]
     pub paused: bool,
     /// Create the root folder. Possible values are `"true"`, `"false"`, unset (default)
+    #[builder(setter(into, strip_option), default)]
     pub root_folder: Option<String>,
     /// Rename torrent
+    #[builder(setter(into, strip_option), default)]
     pub rename: Option<String>,
     /// Set torrent upload speed limit. Unit in bytes/second
+    #[builder(setter(into, strip_option), default)]
     pub up_limit: Option<i64>,
     /// Set torrent download speed limit. Unit in bytes/second
+    #[builder(setter(into, strip_option), default)]
     pub dl_limit: Option<i64>,
     /// Set torrent share ratio limit
+    #[builder(setter(into, strip_option), default)]
     pub ratio_limit: Option<f32>,
     /// Set torrent seeding time limit. Unit in minutes
+    #[builder(setter(into, strip_option), default)]
     pub seeding_time_limit: Option<i64>,
     /// Whether Automatic Torrent Management should be used
+    #[builder(default)]
     pub auto_tmm: bool,
     /// Enable sequential download. Possible values are `true`, `false` (default)
+    #[builder(default)]
     pub sequential_download: bool,
     /// Prioritize download first last piece. Possible values are `true`, `false` (default)
+    #[builder(default)]
     pub first_last_piece_prio: bool,
 }
 
@@ -276,7 +291,7 @@ impl AddTorrent {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub enum AddTorrentType {
     Links(Vec<String>),
     Files(Vec<TorrentFile>),
@@ -297,7 +312,7 @@ impl Default for AddTorrentType {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct TorrentFile {
     pub filename: String,
     pub data: Vec<u8>,

--- a/src/parameters.rs
+++ b/src/parameters.rs
@@ -31,7 +31,7 @@ pub struct TorrentListParams {
 }
 
 /// Possible Torrent states
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub enum TorrentState {
     All,
     Downloading,

--- a/src/parameters.rs
+++ b/src/parameters.rs
@@ -2,28 +2,36 @@ use derive_builder::Builder;
 use std::fmt::Display;
 
 /// Torrent List/info parameter object
-#[derive(Debug, Default)]
+#[derive(Debug, Default, Builder)]
 pub struct TorrentListParams {
     /// Filter torrent list by state. Allowed state filters: TorrentState
+    #[builder(setter(strip_option), default)]
     pub filter: Option<TorrentState>,
     /// Get torrents with the given category (empty string means "without category"; no "category" parameter means "any category"). Remember to URL-encode the category name. For example, `My category` becomes `My%20category`
+    #[builder(setter(into, strip_option), default)]
     pub category: Option<String>,
     /// Get torrents with the given tag (empty string means "without tag"; no "tag" parameter means "any tag". Remember to URL-encode the category name. For example, `My tag` becomes `My%20tag`
+    #[builder(setter(into, strip_option), default)]
     pub tag: Option<String>,
     /// Sort torrents by given key. They can be sorted using any field of the response's JSON array (which are documented below) as the sort key.
+    #[builder(setter(strip_option), default)]
     pub sort: Option<TorrentSort>,
     /// Enable reverse sorting. Defaults to `false`
+    #[builder(default)]
     pub reverse: bool,
     /// Limit the number of torrents returned
+    #[builder(setter(into, strip_option), default)]
     pub limit: Option<i64>,
     /// Set offset (if less than 0, offset from end)
+    #[builder(setter(into, strip_option), default)]
     pub offset: Option<i64>,
     /// Filter by hashes. Can contain multiple hashes separated by `|`
+    #[builder(setter(into, strip_option), default)]
     pub hashes: Option<Vec<String>>,
 }
 
 /// Posibel Torrent states
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub enum TorrentState {
     All,
     Downloading,
@@ -63,7 +71,7 @@ impl Display for TorrentState {
 }
 
 /// Torrent sort fields
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub enum TorrentSort {
     /// Time when the torrent was added to the client
     AddedOn,

--- a/src/parameters.rs
+++ b/src/parameters.rs
@@ -232,6 +232,7 @@ pub struct AddTorrent {
     /// A list of torrent files or magnet links to be added.
     ///
     /// This field is required and must contain at least one item.
+    #[builder(setter(into))]
     pub torrents: AddTorrentType,
     /// Download folder
     #[builder(setter(into, strip_option), default)]
@@ -311,6 +312,18 @@ impl AddTorrentType {
             AddTorrentType::Links(items) => items.is_empty(),
             AddTorrentType::Files(items) => items.is_empty(),
         }
+    }
+}
+
+impl From<Vec<String>> for AddTorrentType {
+    fn from(value: Vec<String>) -> Self {
+        Self::Links(value)
+    }
+}
+
+impl From<Vec<TorrentFile>> for AddTorrentType {
+    fn from(value: Vec<TorrentFile>) -> Self {
+        Self::Files(value)
     }
 }
 

--- a/tests/mod.rs
+++ b/tests/mod.rs
@@ -1,8 +1,5 @@
 use dotenv::dotenv;
-use qbit::{
-    Api,
-    parameters::{AddTorrentBuilder, AddTorrentType},
-};
+use qbit::{Api, parameters::AddTorrentBuilder};
 use std::env;
 
 pub mod authentication;

--- a/tests/mod.rs
+++ b/tests/mod.rs
@@ -1,7 +1,7 @@
 use dotenv::dotenv;
 use qbit::{
     Api,
-    parameters::{AddTorrent, AddTorrentType},
+    parameters::{AddTorrentBuilder, AddTorrentType},
 };
 use std::env;
 
@@ -43,13 +43,15 @@ pub async fn login_default_client() -> Api {
         &get_server_password(),
     )
     .await
-    .expect("Failed to log in to the default client. Please check the server details, username, and password. : ")
+    .expect("Failed to log in to the default client. Please check the server details, username, and password.")
 }
 
 pub async fn add_debian_torrent(client: &Api) {
-    let mut param = AddTorrent::new();
-    param.torrents = AddTorrentType::Links(vec![DEBIAN_TRACKER.to_string()]);
-    param.paused = true;
+    let param = AddTorrentBuilder::default()
+        .torrents(vec![DEBIAN_TRACKER.to_string()])
+        .paused(true)
+        .build()
+        .expect("Failed to build AddTorrent");
 
     client
         .add_torrent(param)


### PR DESCRIPTION
With the help of [derive_builder](https://crates.io/crates/derive_builder), it is now possible (with this PR) to use builders.

## Code
```rs
use qbit::parameters::{AddTorrent, AddTorrentBuilder, AddTorrentType};

fn main() {
    let builder = AddTorrentBuilder::default()
        .root_folder("true")
        .savepath("/home/jellyfin")
        .paused(true)
        .torrents(vec!["hauifoisjoj4892fidnso".to_string()])
        .build();

    let mut manual = AddTorrent::new();
    manual.root_folder = Some("true".to_string());
    manual.savepath = Some("/home/jellyfin".to_string());
    manual.paused = true;
    manual.torrents = AddTorrentType::Links(vec!["hauifoisjoj4892fidnso".to_string()]);

    println!("{:?}", builder.unwrap());
    println!("{:?}", manual);
}
```
Outputs:
```sh
   Compiling qbit v0.1.2 (/tmp/tmp.JZeBbOwHpG/qbittorrent-webui-api)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 1.41s
     Running `target/debug/qbit`
AddTorrent { torrents: Links(["hauifoisjoj4892fidnso"]), savepath: Some("/home/jellyfin"), category: None, tags: None, skip_checking: false, paused: true, root_folder: Some("true"), rename: None, up_limit: None, dl_limit: None, ratio_limit: None, seeding_time_limit: None, auto_tmm: false, sequential_download: false, first_last_piece_prio: false }
AddTorrent { torrents: Links(["hauifoisjoj4892fidnso"]), savepath: Some("/home/jellyfin"), category: None, tags: None, skip_checking: false, paused: true, root_folder: Some("true"), rename: None, up_limit: None, dl_limit: None, ratio_limit: None, seeding_time_limit: None, auto_tmm: false, sequential_download: false, first_last_piece_prio: false }
```
Either option can be used, so it doesn't hurt to add. Especially as it's more of a external use thing than internal use.
In a way, the builder option fells more natural for rust, especially with things like `reqwest` being builder orientated.

## From for AddTorrentType
https://github.com/dragmine149/qbittorrent-webui-api/blob/b4842fab559447630621e773212e2ac6647ba0c2/src/parameters.rs#L318-L329
This just allows us to skip a step, kinda did this experimentaly as 
```rs
.torrents(vec!["hauifoisjoj4892fidnso".to_string()])
```
fells more natural than
```rs
.torrents(AddTorrentType::Links(vec![
   "hauifoisjoj4892fidnso".to_string(),
]))
```

```rs
manual.torrents = vec!["hauifoisjoj4892fidnso".to_string()].into();
```
does also work instead of 
```rs
manual.torrents = AddTorrentType::Links(vec!["hauifoisjoj4892fidnso".to_string()]);
```
but thats slightly different.

## Other areas
I fell like this could be added to more areas as well, specifically areas where a function takes in a custom struct that we expect the user to use. However i haven't touched many other areas outside these so i'm not fully sure.