### PR TITLE
Fix: infinite recursion in error Display Impression 

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -32,7 +32,18 @@ impl From<url::ParseError> for Error {
 
 impl std::fmt::Display for Error {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{self}")
+        write!(
+            f,
+            "{}",
+            match self {
+                Self::AuthFailed(e) => e.to_string(),
+                Self::InvalidResponse(e) => e.to_string(),
+                Self::InvalidRequest(e) => e.to_string(),
+                Self::ReqwestError(e) => e.to_string(),
+                Self::UrlParseError(e) => e.to_string(),
+                Self::SerdeJsonError(e) => e.to_string(),
+            }
+        )
     }
 }
 


### PR DESCRIPTION
I ran `cargo clippy` and found out, that my last PR was bad (sorry about that):
```
error: using `self` as `Display` in `impl Display` will cause infinite recursion
  --> src/error.rs:35:9
   |
35 |         write!(f, "{self}")
   |         ^^^^^^^^^^^^^^^^^^^
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#recursive_format_impl
   = note: `#[deny(clippy::recursive_format_impl)]` on by default
   = note: this error originates in the macro `write` (in Nightly builds, run with -Z macro-backtrace for more info)
```
I fixed it and fixed the other stuff clippy complained about too.

If you visit the link it says:

### What it does

Checks for format trait implementations (e.g. Display) with a recursive call to itself which uses self as a parameter. This is typically done indirectly with the write! macro or with to_string().

### Why is this bad?

This will lead to infinite recursion and a stack overflow.



