### PR TITLE
derive Clone for everyhing

### DIFF
--- a/src/models/application.rs
+++ b/src/models/application.rs
@@ -4,7 +4,7 @@ use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use serde_repr::{Deserialize_repr, Serialize_repr};
 
 /// Build info response data object.
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Debug, Deserialize, Serialize, Clone)]
 pub struct BuildInfo {
     /// QT version
     pub qt: String,
@@ -18,7 +18,7 @@ pub struct BuildInfo {
     pub bitness: u8,
 }
 /// Preferences response data object.
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Debug, Deserialize, Serialize, Clone)]
 pub struct Preferences {
     // ========== General Settings ==========
     /// Currently selected language (e.g. en_GB for English)
@@ -433,7 +433,7 @@ impl std::fmt::Display for ContentLayout {
 }
 
 /// When does the torrent stop
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, Clone)]
 pub enum StopCondition {
     /// Don't stop and go straight to downloading
     None,
@@ -460,7 +460,7 @@ impl std::fmt::Display for StopCondition {
 }
 
 /// What to do when removing content files upon removing a torrent.
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, Clone)]
 pub enum TorrentDeletion {
     /// Erase from disk permanatly
     Delete,
@@ -484,7 +484,7 @@ impl std::fmt::Display for TorrentDeletion {
 }
 
 /// Scan dir types
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub enum ScanDir {
     MonitoredFolder,
     DefaultSavePath,
@@ -528,7 +528,7 @@ impl Serialize for ScanDir {
 }
 
 /// Ratio actions
-#[derive(Debug, Deserialize_repr, Serialize_repr)]
+#[derive(Debug, Deserialize_repr, Serialize_repr, Clone)]
 #[repr(u8)]
 pub enum RatioAct {
     PauseTorrent = 0,
@@ -536,7 +536,7 @@ pub enum RatioAct {
 }
 
 /// Bittorrent protocols
-#[derive(Debug, Deserialize_repr, Serialize_repr)]
+#[derive(Debug, Deserialize_repr, Serialize_repr, Clone)]
 #[repr(u8)]
 pub enum BittorrentProtocol {
     Tcpμtp = 0,
@@ -545,7 +545,7 @@ pub enum BittorrentProtocol {
 }
 
 /// Scheduler
-#[derive(Debug, Deserialize_repr, Serialize_repr)]
+#[derive(Debug, Deserialize_repr, Serialize_repr, Clone)]
 #[repr(u8)]
 pub enum SchedulerTime {
     /// Every day
@@ -571,7 +571,7 @@ pub enum SchedulerTime {
 }
 
 /// Encryption states
-#[derive(Debug, Deserialize_repr, Serialize_repr)]
+#[derive(Debug, Deserialize_repr, Serialize_repr, Clone)]
 #[repr(u8)]
 pub enum Encryption {
     Prefer = 0,
@@ -580,7 +580,7 @@ pub enum Encryption {
 }
 
 /// Proxy types states
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub enum ProxyType {
     Disabled,
     Other(String),
@@ -636,7 +636,7 @@ impl Serialize for ProxyType {
 }
 
 /// Dyndns servcice types
-#[derive(Debug, Deserialize_repr, Serialize_repr)]
+#[derive(Debug, Deserialize_repr, Serialize_repr, Clone)]
 #[repr(u8)]
 pub enum DyndnsService {
     Dydns = 0,
@@ -644,7 +644,7 @@ pub enum DyndnsService {
 }
 
 /// Upload choking algorithm
-#[derive(Debug, Deserialize_repr, Serialize_repr)]
+#[derive(Debug, Deserialize_repr, Serialize_repr, Clone)]
 #[repr(u8)]
 pub enum UploadChokingAlgorithm {
     RoundRobin = 0,
@@ -653,7 +653,7 @@ pub enum UploadChokingAlgorithm {
 }
 
 /// Upload slots behavior
-#[derive(Debug, Deserialize_repr, Serialize_repr)]
+#[derive(Debug, Deserialize_repr, Serialize_repr, Clone)]
 #[repr(u8)]
 pub enum UploadSlotsBehavior {
     Fixed = 0,
@@ -661,13 +661,13 @@ pub enum UploadSlotsBehavior {
 }
 
 /// Mix mode UTP / TCP
-#[derive(Debug, Deserialize_repr, Serialize_repr)]
+#[derive(Debug, Deserialize_repr, Serialize_repr, Clone)]
 #[repr(u8)]
 pub enum UtpTcpMixedMode {
     PreferTcp = 0,
     PeerProportional = 1,
 }
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Debug, Deserialize, Serialize, Clone)]
 pub struct Cookie {
     /// The name of the cookie.
     pub name: String,

--- a/src/models/log.rs
+++ b/src/models/log.rs
@@ -2,7 +2,7 @@ use serde::{Deserialize, Serialize};
 use serde_repr::{Deserialize_repr, Serialize_repr};
 
 /// Log item data object
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Debug, Deserialize, Serialize, Clone)]
 pub struct LogItem {
     /// ID of the message
     pub id: i64,
@@ -20,7 +20,7 @@ pub struct LogItem {
 /// Log types
 ///
 /// Log levels used by the logger
-#[derive(Debug, Deserialize_repr, Serialize_repr)]
+#[derive(Debug, Deserialize_repr, Serialize_repr, Clone)]
 #[repr(u8)]
 pub enum LogType {
     Normal = 1,
@@ -30,7 +30,7 @@ pub enum LogType {
 }
 
 /// Peer log item data object
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Debug, Deserialize, Serialize, Clone)]
 pub struct LogPeers {
     /// ID of the peer
     pub id: i64,

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -17,7 +17,7 @@ pub use torrent::*;
 pub use transfer::*;
 
 /// Connection status of the Qbit application
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Debug, Deserialize, Serialize, Clone)]
 pub enum ConnectionStatus {
     #[serde(rename = "connected")]
     Connected,

--- a/src/models/rss.rs
+++ b/src/models/rss.rs
@@ -3,7 +3,7 @@ use std::collections::HashMap;
 use serde::{Deserialize, Serialize};
 
 /// This module defines structures for representing RSS feeds collections.
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Debug, Deserialize, Serialize, Clone)]
 #[serde(untagged)]
 pub enum RssFeedCollection {
     /// Represents a full RSS feed object containing detailed information about the feed.
@@ -15,7 +15,7 @@ pub enum RssFeedCollection {
 }
 
 /// Represents a base RSS feed object with minimal information.
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Debug, Deserialize, Serialize, Clone)]
 pub struct RssFeedBase {
     /// Unique identifier for the RSS feed.
     uid: String,
@@ -24,7 +24,7 @@ pub struct RssFeedBase {
 }
 
 /// Represents a detailed RSS feed object containing full information.
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Debug, Deserialize, Serialize, Clone)]
 pub struct RssFeed {
     /// Unique identifier for the RSS feed.
     uid: String,
@@ -46,7 +46,7 @@ pub struct RssFeed {
 }
 
 /// Represents an article within an RSS feed.
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Debug, Deserialize, Serialize, Clone)]
 pub struct RssArticle {
     /// Identifier for the article.
     id: String,
@@ -63,7 +63,7 @@ pub struct RssArticle {
     date: String,
 }
 
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Debug, Deserialize, Serialize, Clone)]
 pub struct RssRule {
     /// Whether the rule is enabled
     enabled: bool,

--- a/src/models/search.rs
+++ b/src/models/search.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Debug, Deserialize, Serialize, Clone)]
 pub struct Search {
     /// ID of the search job
     pub id: u64,
@@ -10,13 +10,13 @@ pub struct Search {
     pub total: u64,
 }
 
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Debug, Deserialize, Serialize, Clone)]
 pub enum SearchStatus {
     Running,
     Stopped,
 }
 
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Debug, Deserialize, Serialize, Clone)]
 pub struct SearchResult {
     /// List of `SearchResultItem`.
     pub results: Vec<SearchResultItem>,
@@ -26,7 +26,7 @@ pub struct SearchResult {
     pub total: u64,
 }
 
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Debug, Deserialize, Serialize, Clone)]
 pub struct SearchResultItem {
     /// URL pointing to the torrent's description page on the source site.
     #[serde(rename = "descrLink")]
@@ -51,7 +51,7 @@ pub struct SearchResultItem {
     pub site_url: String,
 }
 
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Debug, Deserialize, Serialize, Clone)]
 pub struct SearchPlugin {
     /// Whether the plugin is enabled.
     pub enabled: bool,
@@ -69,7 +69,7 @@ pub struct SearchPlugin {
     pub version: String,
 }
 
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Debug, Deserialize, Serialize, Clone)]
 pub struct SearchCategory {
     /// Identifier for the category (e.g., "all", "books", "tv").
     pub id: String,

--- a/src/models/sync.rs
+++ b/src/models/sync.rs
@@ -5,7 +5,7 @@ use serde::{Deserialize, Serialize};
 use crate::models::{ConnectionStatus, TorrentsMap};
 
 /// Main response data object
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Debug, Deserialize, Serialize, Clone)]
 pub struct MainData {
     /// Response ID
     pub rid: i64,
@@ -32,7 +32,7 @@ pub struct MainData {
 }
 
 /// Category response data object
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Debug, Deserialize, Serialize, Clone)]
 pub struct Category {
     /// Category name
     pub name: String,
@@ -42,7 +42,7 @@ pub struct Category {
 }
 
 /// Server state response data object.
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Debug, Deserialize, Serialize, Clone)]
 pub struct ServerState {
     /// Alltime download
     pub alltime_dl: i64,
@@ -95,7 +95,7 @@ pub struct ServerState {
 }
 
 /// Peers response data object.
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Debug, Deserialize, Serialize, Clone)]
 pub struct PeersData {
     /// Response ID
     pub rid: i64,
@@ -109,7 +109,7 @@ pub struct PeersData {
 }
 
 /// Peer response data object.
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Debug, Deserialize, Serialize, Clone)]
 pub struct Peer {
     /// Client used by the peer. (μTorrent, qBittorrent, etc...)
     pub client: Option<String>,

--- a/src/models/torrent.rs
+++ b/src/models/torrent.rs
@@ -7,7 +7,7 @@ use serde::{
 use serde_repr::{Deserialize_repr, Serialize_repr};
 
 /// Torrent info response object
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Debug, Deserialize, Serialize, Clone)]
 pub struct Torrent {
     /// Time (Unix Epoch) when the torrent was added to the client
     pub added_on: i64,
@@ -132,7 +132,7 @@ pub struct Torrent {
     pub upspeed: i64,
 }
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, Clone)]
 pub struct TorrentsMap(pub HashMap<String, Torrent>);
 
 impl Deref for TorrentsMap {
@@ -297,7 +297,7 @@ impl<'de> Visitor<'de> for TorrentMapVisitor {
 }
 
 /// Generic torrent properties
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Debug, Deserialize, Serialize, Clone)]
 pub struct TorrentProperties {
     /// Torrent save path
     pub save_path: String,
@@ -373,7 +373,7 @@ pub struct TorrentProperties {
 }
 
 /// Torrent tracker data object
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Debug, Deserialize, Serialize, Clone)]
 pub struct Tracker {
     /// Tracker url
     pub url: String,
@@ -394,14 +394,14 @@ pub struct Tracker {
 }
 
 /// Web seed data object
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Debug, Deserialize, Serialize, Clone)]
 pub struct WebSeed {
     /// Web seed URL
     pub url: String,
 }
 
 /// Torrent file/content data object
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Debug, Deserialize, Serialize, Clone)]
 pub struct TorrentContent {
     /// File index
     pub index: i64,
@@ -422,7 +422,7 @@ pub struct TorrentContent {
 }
 
 /// File priority enum
-#[derive(Debug, Deserialize_repr, Serialize_repr)]
+#[derive(Debug, Deserialize_repr, Serialize_repr, Clone)]
 #[repr(u8)]
 pub enum FilePriority {
     /// Do not download
@@ -436,7 +436,7 @@ pub enum FilePriority {
 }
 
 /// Pices state
-#[derive(Debug, Deserialize_repr, Serialize_repr)]
+#[derive(Debug, Deserialize_repr, Serialize_repr, Clone)]
 #[repr(u8)]
 pub enum PiecesState {
     NotDownloaded = 0,

--- a/src/models/transfer.rs
+++ b/src/models/transfer.rs
@@ -5,7 +5,7 @@ use crate::models::ConnectionStatus;
 /// Transfer info data object
 ///
 /// This is the data that whuld usually se in the Qbit status bar.
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Debug, Deserialize, Serialize, Clone)]
 pub struct TransferInfo {
     /// Global download rate (bytes/s)
     pub dl_info_speed: i64,

--- a/src/parameters.rs
+++ b/src/parameters.rs
@@ -4,7 +4,7 @@ use std::fmt::Display;
 use crate::models::ContentLayout;
 
 /// Torrent List/info parameter object
-#[derive(Debug, Default, Builder)]
+#[derive(Debug, Default, Builder, Clone)]
 pub struct TorrentListParams {
     /// Filter torrent list by state. Allowed state filters: TorrentState
     #[builder(setter(strip_option), default)]
@@ -229,7 +229,7 @@ impl Display for TorrentSort {
 }
 
 /// Add torrent parameter object
-#[derive(Debug, Default, Builder)]
+#[derive(Debug, Default, Builder, Clone)]
 pub struct AddTorrent {
     /// A list of torrent files or magnet links to be added.
     ///


### PR DESCRIPTION
As per the [Rust API Guidelines](https://rust-lang.github.io/api-guidelines/interoperability.html#c-common-traits) I derived `Clone` wherever it was possible.
