### PR TITLE
derive more Traits as per the API Guidelines

### DIFF
--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -18,6 +18,7 @@ mod torrent;
 mod transfer;
 
 /// Represents a client for interacting with a remote API, handling HTTP requests.
+#[derive(Debug)]
 pub struct Api {
     http_client: ReqwestClient,
     base_url: tokio::sync::RwLock<Url>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,6 +10,7 @@ use std::fmt::Display;
 
 pub use client::Api;
 pub use error::Error;
+use serde::{Deserialize, Serialize};
 
 /// Login state
 ///
@@ -17,7 +18,7 @@ pub use error::Error;
 ///
 /// Inspired by the design from [George-Miao qbit repo](https://github.com/George-Miao/qbit) -
 /// [Commit](https://github.com/George-Miao/qbit/commit/fe1240c05b4d3feeafb327e8ba7f0eeba97735c5#diff-b1a35a68f14e696205874893c07fd24fdb88882b47c23cc0e0c80a30c7d53759R28)
-#[derive(Clone)]
+#[derive(Debug, Deserialize, Serialize, Clone, Default, PartialEq)]
 pub enum LoginState {
     LoggedIn {
         credentials: Credentials,
@@ -29,6 +30,7 @@ pub enum LoginState {
     CookieProvidet {
         cookie_sid: String,
     },
+    #[default]
     Unknown,
 }
 
@@ -78,7 +80,7 @@ impl LoginState {
 }
 
 /// The `Credentials` struct represents a user's login credentials.
-#[derive(Clone)]
+#[derive(Debug, Deserialize, Serialize, Clone, Default, PartialEq)]
 pub struct Credentials {
     username: String,
     password: String,

--- a/src/models/application.rs
+++ b/src/models/application.rs
@@ -4,7 +4,7 @@ use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use serde_repr::{Deserialize_repr, Serialize_repr};
 
 /// Build info response data object.
-#[derive(Debug, Deserialize, Serialize, Clone)]
+#[derive(Debug, Deserialize, Serialize, Clone, Default, PartialEq)]
 pub struct BuildInfo {
     /// QT version
     pub qt: String,
@@ -18,7 +18,7 @@ pub struct BuildInfo {
     pub bitness: u8,
 }
 /// Preferences response data object.
-#[derive(Debug, Deserialize, Serialize, Clone)]
+#[derive(Debug, Deserialize, Serialize, Clone, Default, PartialEq)]
 pub struct Preferences {
     // ========== General Settings ==========
     /// Currently selected language (e.g. en_GB for English)
@@ -404,9 +404,10 @@ pub struct Preferences {
 }
 
 /// How the torrent content is laied out.
-#[derive(Debug, Serialize, Deserialize, Clone)]
+#[derive(Debug, Deserialize, Serialize, Clone, Default, PartialEq)]
 pub enum ContentLayout {
     /// Does whatever the server says to do, which by default is Subfolder
+    #[default]
     Original,
     /// In cases of batches, will create a separate subfolder automatically of the batch name.
     /// Example: `Save_path/Torrent_name/Torrent_files`
@@ -414,12 +415,6 @@ pub enum ContentLayout {
     /// In cases of batches, will just place them all in the save_path.
     /// Example: `Save_path/Torrent_files`
     NoSubfolder,
-}
-
-impl Default for ContentLayout {
-    fn default() -> Self {
-        Self::Original
-    }
 }
 
 impl std::fmt::Display for ContentLayout {
@@ -433,20 +428,15 @@ impl std::fmt::Display for ContentLayout {
 }
 
 /// When does the torrent stop
-#[derive(Debug, Serialize, Deserialize, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone, Default, PartialEq)]
 pub enum StopCondition {
     /// Don't stop and go straight to downloading
+    #[default]
     None,
     /// Stop after receiving the metadata
     MetadataReceived,
     /// Stop after checking the files.
     FilesChecked,
-}
-
-impl Default for StopCondition {
-    fn default() -> Self {
-        Self::None
-    }
 }
 
 impl std::fmt::Display for StopCondition {
@@ -460,18 +450,13 @@ impl std::fmt::Display for StopCondition {
 }
 
 /// What to do when removing content files upon removing a torrent.
-#[derive(Debug, Serialize, Deserialize, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone, Default, PartialEq)]
 pub enum TorrentDeletion {
     /// Erase from disk permanatly
+    #[default]
     Delete,
     /// Attempts to move to Trash/Wastebin if possible.
     MoveToTrash,
-}
-
-impl Default for TorrentDeletion {
-    fn default() -> Self {
-        Self::Delete
-    }
 }
 
 impl std::fmt::Display for TorrentDeletion {
@@ -484,9 +469,10 @@ impl std::fmt::Display for TorrentDeletion {
 }
 
 /// Scan dir types
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default, PartialEq)]
 pub enum ScanDir {
     MonitoredFolder,
+    #[default]
     DefaultSavePath,
     OtherPath(String),
 }
@@ -528,27 +514,30 @@ impl Serialize for ScanDir {
 }
 
 /// Ratio actions
-#[derive(Debug, Deserialize_repr, Serialize_repr, Clone)]
+#[derive(Debug, Deserialize_repr, Serialize_repr, Clone, Default, PartialEq)]
 #[repr(u8)]
 pub enum RatioAct {
+    #[default]
     PauseTorrent = 0,
     RemoveTorrent = 1,
 }
 
 /// Bittorrent protocols
-#[derive(Debug, Deserialize_repr, Serialize_repr, Clone)]
+#[derive(Debug, Deserialize_repr, Serialize_repr, Clone, Default, PartialEq)]
 #[repr(u8)]
 pub enum BittorrentProtocol {
     Tcpμtp = 0,
+    #[default]
     Tcp = 1,
     MicroTransportProtocol = 2,
 }
 
 /// Scheduler
-#[derive(Debug, Deserialize_repr, Serialize_repr, Clone)]
+#[derive(Debug, Deserialize_repr, Serialize_repr, Clone, Default, PartialEq)]
 #[repr(u8)]
 pub enum SchedulerTime {
     /// Every day
+    #[default]
     Day = 0,
     /// Every Weekday
     Weekday = 1,
@@ -571,17 +560,19 @@ pub enum SchedulerTime {
 }
 
 /// Encryption states
-#[derive(Debug, Deserialize_repr, Serialize_repr, Clone)]
+#[derive(Debug, Deserialize_repr, Serialize_repr, Clone, Default, PartialEq)]
 #[repr(u8)]
 pub enum Encryption {
+    #[default]
     Prefer = 0,
     ForceOn = 1,
     ForceOff = 2,
 }
 
 /// Proxy types states
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default, PartialEq)]
 pub enum ProxyType {
+    #[default]
     Disabled,
     Other(String),
     HttpWithoutAuth,
@@ -636,38 +627,42 @@ impl Serialize for ProxyType {
 }
 
 /// Dyndns servcice types
-#[derive(Debug, Deserialize_repr, Serialize_repr, Clone)]
+#[derive(Debug, Deserialize_repr, Serialize_repr, Clone, Default, PartialEq)]
 #[repr(u8)]
 pub enum DyndnsService {
+    #[default]
     Dydns = 0,
     Noip = 1,
 }
 
 /// Upload choking algorithm
-#[derive(Debug, Deserialize_repr, Serialize_repr, Clone)]
+#[derive(Debug, Deserialize_repr, Serialize_repr, Clone, Default, PartialEq)]
 #[repr(u8)]
 pub enum UploadChokingAlgorithm {
+    #[default]
     RoundRobin = 0,
     FastestUpload = 1,
     AntiLeech = 2,
 }
 
 /// Upload slots behavior
-#[derive(Debug, Deserialize_repr, Serialize_repr, Clone)]
+#[derive(Debug, Deserialize_repr, Serialize_repr, Clone, Default, PartialEq)]
 #[repr(u8)]
 pub enum UploadSlotsBehavior {
+    #[default]
     Fixed = 0,
     UploadRate = 1,
 }
 
 /// Mix mode UTP / TCP
-#[derive(Debug, Deserialize_repr, Serialize_repr, Clone)]
+#[derive(Debug, Deserialize_repr, Serialize_repr, Clone, Default, PartialEq)]
 #[repr(u8)]
 pub enum UtpTcpMixedMode {
+    #[default]
     PreferTcp = 0,
     PeerProportional = 1,
 }
-#[derive(Debug, Deserialize, Serialize, Clone)]
+#[derive(Debug, Deserialize, Serialize, Clone, Default, PartialEq)]
 pub struct Cookie {
     /// The name of the cookie.
     pub name: String,

--- a/src/models/log.rs
+++ b/src/models/log.rs
@@ -2,7 +2,7 @@ use serde::{Deserialize, Serialize};
 use serde_repr::{Deserialize_repr, Serialize_repr};
 
 /// Log item data object
-#[derive(Debug, Deserialize, Serialize, Clone)]
+#[derive(Debug, Deserialize, Serialize, Clone, Default, PartialEq)]
 pub struct LogItem {
     /// ID of the message
     pub id: i64,
@@ -20,9 +20,10 @@ pub struct LogItem {
 /// Log types
 ///
 /// Log levels used by the logger
-#[derive(Debug, Deserialize_repr, Serialize_repr, Clone)]
+#[derive(Debug, Deserialize_repr, Serialize_repr, Clone, Default, PartialEq)]
 #[repr(u8)]
 pub enum LogType {
+    #[default]
     Normal = 1,
     Info = 2,
     Warning = 4,
@@ -30,7 +31,7 @@ pub enum LogType {
 }
 
 /// Peer log item data object
-#[derive(Debug, Deserialize, Serialize, Clone)]
+#[derive(Debug, Deserialize, Serialize, Clone, Default, PartialEq)]
 pub struct LogPeers {
     /// ID of the peer
     pub id: i64,

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -17,12 +17,13 @@ pub use torrent::*;
 pub use transfer::*;
 
 /// Connection status of the Qbit application
-#[derive(Debug, Deserialize, Serialize, Clone)]
+#[derive(Debug, Deserialize, Serialize, Clone, Default, PartialEq)]
 pub enum ConnectionStatus {
     #[serde(rename = "connected")]
     Connected,
     #[serde(rename = "firewalled")]
     Firewalled,
     #[serde(rename = "disconnected")]
+    #[default]
     Disconnected,
 }

--- a/src/models/rss.rs
+++ b/src/models/rss.rs
@@ -3,7 +3,7 @@ use std::collections::HashMap;
 use serde::{Deserialize, Serialize};
 
 /// This module defines structures for representing RSS feeds collections.
-#[derive(Debug, Deserialize, Serialize, Clone)]
+#[derive(Debug, Deserialize, Serialize, Clone, PartialEq)]
 #[serde(untagged)]
 pub enum RssFeedCollection {
     /// Represents a full RSS feed object containing detailed information about the feed.
@@ -15,7 +15,7 @@ pub enum RssFeedCollection {
 }
 
 /// Represents a base RSS feed object with minimal information.
-#[derive(Debug, Deserialize, Serialize, Clone)]
+#[derive(Debug, Deserialize, Serialize, Clone, Default, PartialEq)]
 pub struct RssFeedBase {
     /// Unique identifier for the RSS feed.
     uid: String,
@@ -24,7 +24,7 @@ pub struct RssFeedBase {
 }
 
 /// Represents a detailed RSS feed object containing full information.
-#[derive(Debug, Deserialize, Serialize, Clone)]
+#[derive(Debug, Deserialize, Serialize, Clone, Default, PartialEq)]
 pub struct RssFeed {
     /// Unique identifier for the RSS feed.
     uid: String,
@@ -46,7 +46,7 @@ pub struct RssFeed {
 }
 
 /// Represents an article within an RSS feed.
-#[derive(Debug, Deserialize, Serialize, Clone)]
+#[derive(Debug, Deserialize, Serialize, Clone, Default, PartialEq)]
 pub struct RssArticle {
     /// Identifier for the article.
     id: String,
@@ -63,7 +63,7 @@ pub struct RssArticle {
     date: String,
 }
 
-#[derive(Debug, Deserialize, Serialize, Clone)]
+#[derive(Debug, Deserialize, Serialize, Clone, Default, PartialEq)]
 pub struct RssRule {
     /// Whether the rule is enabled
     enabled: bool,

--- a/src/models/search.rs
+++ b/src/models/search.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Deserialize, Serialize, Clone)]
+#[derive(Debug, Deserialize, Serialize, Clone, Default, PartialEq)]
 pub struct Search {
     /// ID of the search job
     pub id: u64,
@@ -10,13 +10,14 @@ pub struct Search {
     pub total: u64,
 }
 
-#[derive(Debug, Deserialize, Serialize, Clone)]
+#[derive(Debug, Deserialize, Serialize, Clone, Default, PartialEq)]
 pub enum SearchStatus {
     Running,
+    #[default]
     Stopped,
 }
 
-#[derive(Debug, Deserialize, Serialize, Clone)]
+#[derive(Debug, Deserialize, Serialize, Clone, Default, PartialEq)]
 pub struct SearchResult {
     /// List of `SearchResultItem`.
     pub results: Vec<SearchResultItem>,
@@ -26,7 +27,7 @@ pub struct SearchResult {
     pub total: u64,
 }
 
-#[derive(Debug, Deserialize, Serialize, Clone)]
+#[derive(Debug, Deserialize, Serialize, Clone, Default, PartialEq)]
 pub struct SearchResultItem {
     /// URL pointing to the torrent's description page on the source site.
     #[serde(rename = "descrLink")]
@@ -51,7 +52,7 @@ pub struct SearchResultItem {
     pub site_url: String,
 }
 
-#[derive(Debug, Deserialize, Serialize, Clone)]
+#[derive(Debug, Deserialize, Serialize, Clone, Default, PartialEq)]
 pub struct SearchPlugin {
     /// Whether the plugin is enabled.
     pub enabled: bool,
@@ -69,7 +70,7 @@ pub struct SearchPlugin {
     pub version: String,
 }
 
-#[derive(Debug, Deserialize, Serialize, Clone)]
+#[derive(Debug, Deserialize, Serialize, Clone, Default, PartialEq)]
 pub struct SearchCategory {
     /// Identifier for the category (e.g., "all", "books", "tv").
     pub id: String,

--- a/src/models/sync.rs
+++ b/src/models/sync.rs
@@ -5,7 +5,7 @@ use serde::{Deserialize, Serialize};
 use crate::models::{ConnectionStatus, TorrentsMap};
 
 /// Main response data object
-#[derive(Debug, Deserialize, Serialize, Clone)]
+#[derive(Debug, Deserialize, Serialize, Clone, Default, PartialEq)]
 pub struct MainData {
     /// Response ID
     pub rid: i64,
@@ -32,7 +32,7 @@ pub struct MainData {
 }
 
 /// Category response data object
-#[derive(Debug, Deserialize, Serialize, Clone)]
+#[derive(Debug, Deserialize, Serialize, Clone, Default, PartialEq)]
 pub struct Category {
     /// Category name
     pub name: String,
@@ -42,7 +42,7 @@ pub struct Category {
 }
 
 /// Server state response data object.
-#[derive(Debug, Deserialize, Serialize, Clone)]
+#[derive(Debug, Deserialize, Serialize, Clone, Default, PartialEq)]
 pub struct ServerState {
     /// Alltime download
     pub alltime_dl: i64,
@@ -95,7 +95,7 @@ pub struct ServerState {
 }
 
 /// Peers response data object.
-#[derive(Debug, Deserialize, Serialize, Clone)]
+#[derive(Debug, Deserialize, Serialize, Clone, Default, PartialEq)]
 pub struct PeersData {
     /// Response ID
     pub rid: i64,
@@ -109,7 +109,7 @@ pub struct PeersData {
 }
 
 /// Peer response data object.
-#[derive(Debug, Deserialize, Serialize, Clone)]
+#[derive(Debug, Deserialize, Serialize, Clone, Default, PartialEq)]
 pub struct Peer {
     /// Client used by the peer. (μTorrent, qBittorrent, etc...)
     pub client: Option<String>,

--- a/src/models/torrent.rs
+++ b/src/models/torrent.rs
@@ -7,7 +7,7 @@ use serde::{
 use serde_repr::{Deserialize_repr, Serialize_repr};
 
 /// Torrent info response object
-#[derive(Debug, Deserialize, Serialize, Clone, Default)]
+#[derive(Debug, Deserialize, Serialize, Clone, Default, PartialEq)]
 pub struct Torrent {
     /// Time (Unix Epoch) when the torrent was added to the client
     pub added_on: i64,
@@ -132,7 +132,7 @@ pub struct Torrent {
     pub upspeed: i64,
 }
 
-#[derive(Debug, Serialize, Clone)]
+#[derive(Debug, Serialize, Clone, Default, PartialEq)]
 pub struct TorrentsMap(pub HashMap<String, Torrent>);
 
 impl Deref for TorrentsMap {
@@ -152,6 +152,7 @@ impl<'de> Deserialize<'de> for TorrentsMap {
     }
 }
 
+#[derive(Debug, Deserialize, Serialize, Clone, Default, PartialEq)]
 struct TorrentMapVisitor;
 
 impl<'de> Visitor<'de> for TorrentMapVisitor {
@@ -297,7 +298,7 @@ impl<'de> Visitor<'de> for TorrentMapVisitor {
 }
 
 /// Generic torrent properties
-#[derive(Debug, Deserialize, Serialize, Clone)]
+#[derive(Debug, Deserialize, Serialize, Clone, Default, PartialEq)]
 pub struct TorrentProperties {
     /// Torrent save path
     pub save_path: String,
@@ -373,7 +374,7 @@ pub struct TorrentProperties {
 }
 
 /// Torrent tracker data object
-#[derive(Debug, Deserialize, Serialize, Clone)]
+#[derive(Debug, Deserialize, Serialize, Clone, Default, PartialEq)]
 pub struct Tracker {
     /// Tracker url
     pub url: String,
@@ -394,14 +395,14 @@ pub struct Tracker {
 }
 
 /// Web seed data object
-#[derive(Debug, Deserialize, Serialize, Clone)]
+#[derive(Debug, Deserialize, Serialize, Clone, Default, PartialEq)]
 pub struct WebSeed {
     /// Web seed URL
     pub url: String,
 }
 
 /// Torrent file/content data object
-#[derive(Debug, Deserialize, Serialize, Clone)]
+#[derive(Debug, Deserialize, Serialize, Clone, Default, PartialEq)]
 pub struct TorrentContent {
     /// File index
     pub index: i64,
@@ -422,12 +423,13 @@ pub struct TorrentContent {
 }
 
 /// File priority enum
-#[derive(Debug, Deserialize_repr, Serialize_repr, Clone)]
+#[derive(Debug, Deserialize_repr, Serialize_repr, Clone, Default, PartialEq)]
 #[repr(u8)]
 pub enum FilePriority {
     /// Do not download
     DoNotDownload = 0,
     /// Normal priority
+    #[default]
     Normal = 1,
     /// High priority
     High = 6,
@@ -436,9 +438,10 @@ pub enum FilePriority {
 }
 
 /// Pices state
-#[derive(Debug, Deserialize_repr, Serialize_repr, Clone)]
+#[derive(Debug, Deserialize_repr, Serialize_repr, Clone, Default, PartialEq)]
 #[repr(u8)]
 pub enum PiecesState {
+    #[default]
     NotDownloaded = 0,
     Downloading = 1,
     Downloaded = 2,

--- a/src/models/transfer.rs
+++ b/src/models/transfer.rs
@@ -5,7 +5,7 @@ use crate::models::ConnectionStatus;
 /// Transfer info data object
 ///
 /// This is the data that whuld usually se in the Qbit status bar.
-#[derive(Debug, Deserialize, Serialize, Clone)]
+#[derive(Debug, Deserialize, Serialize, Clone, Default, PartialEq)]
 pub struct TransferInfo {
     /// Global download rate (bytes/s)
     pub dl_info_speed: i64,

--- a/src/parameters.rs
+++ b/src/parameters.rs
@@ -1,10 +1,11 @@
 use derive_builder::Builder;
+use serde::{Deserialize, Serialize};
 use std::fmt::Display;
 
 use crate::models::ContentLayout;
 
 /// Torrent List/info parameter object
-#[derive(Debug, Default, Builder, Clone)]
+#[derive(Debug, Default, Builder, Clone, Deserialize, Serialize, PartialEq)]
 pub struct TorrentListParams {
     /// Filter torrent list by state. Allowed state filters: TorrentState
     #[builder(setter(strip_option), default)]
@@ -33,8 +34,9 @@ pub struct TorrentListParams {
 }
 
 /// Possible Torrent states
-#[derive(Debug, Clone)]
+#[derive(Debug, Deserialize, Serialize, Clone, Default, PartialEq)]
 pub enum TorrentState {
+    #[default]
     All,
     Downloading,
     Seeding,
@@ -73,9 +75,10 @@ impl Display for TorrentState {
 }
 
 /// Torrent sort fields
-#[derive(Debug, Clone)]
+#[derive(Debug, Deserialize, Serialize, Clone, Default, PartialEq)]
 pub enum TorrentSort {
     /// Time when the torrent was added to the client
+    #[default]
     AddedOn,
     /// Amount of data left to download
     AmountLeft,
@@ -176,60 +179,60 @@ impl Display for TorrentSort {
             f,
             "{}",
             match self {
-                Self::AddedOn => String::from("added_on"),
-                Self::AmountLeft => String::from("amount_left"),
-                Self::AutoTmm => String::from("auto_tmm"),
-                Self::Availability => String::from("availability"),
-                Self::Category => String::from("category"),
-                Self::Completed => String::from("completed"),
-                Self::CompletionOn => String::from("completion_on"),
-                Self::ContentPath => String::from("content_path"),
-                Self::DlLimit => String::from("dl_limit"),
-                Self::Dlspeed => String::from("dlspeed"),
-                Self::Downloaded => String::from("downloaded"),
-                Self::DownloadedSession => String::from("downloaded_session"),
-                Self::Eta => String::from("eta"),
-                Self::FLPiecePrio => String::from("f_l_piece_prio"),
-                Self::ForceStart => String::from("force_start"),
-                Self::Hash => String::from("hash"),
-                Self::Private => String::from("private"),
-                Self::LastActivity => String::from("last_activity"),
-                Self::MagnetUri => String::from("magnet_uri"),
-                Self::MaxRatio => String::from("max_ratio"),
-                Self::MaxSeedingTime => String::from("max_seeding_time"),
-                Self::Name => String::from("name"),
-                Self::NumComplete => String::from("num_complete"),
-                Self::NumIncomplete => String::from("num_incomplete"),
-                Self::NumLeechs => String::from("num_leechs"),
-                Self::NumSeeds => String::from("num_seeds"),
-                Self::Priority => String::from("priority"),
-                Self::Progress => String::from("progress"),
-                Self::Ratio => String::from("ratio"),
-                Self::RatioLimit => String::from("ratio_limit"),
-                Self::Reannounce => String::from("reannounce"),
-                Self::SavePath => String::from("save_path"),
-                Self::SeedingTime => String::from("seeding_time"),
-                Self::SeedingTimeLimit => String::from("seeding_time_limit"),
-                Self::SeenComplete => String::from("seen_complete"),
-                Self::SeqDl => String::from("seq_dl"),
-                Self::Size => String::from("size"),
-                Self::State => String::from("state"),
-                Self::SuperSeeding => String::from("super_seeding"),
-                Self::Tags => String::from("tags"),
-                Self::TimeActive => String::from("time_active"),
-                Self::TotalSize => String::from("total_size"),
-                Self::Tracker => String::from("tracker"),
-                Self::UpLimit => String::from("up_limit"),
-                Self::Uploaded => String::from("uploaded"),
-                Self::UploadedSession => String::from("uploaded_session"),
-                Self::Upspeed => String::from("upspeed"),
+                Self::AddedOn => "added_on",
+                Self::AmountLeft => "amount_left",
+                Self::AutoTmm => "auto_tmm",
+                Self::Availability => "availability",
+                Self::Category => "category",
+                Self::Completed => "completed",
+                Self::CompletionOn => "completion_on",
+                Self::ContentPath => "content_path",
+                Self::DlLimit => "dl_limit",
+                Self::Dlspeed => "dlspeed",
+                Self::Downloaded => "downloaded",
+                Self::DownloadedSession => "downloaded_session",
+                Self::Eta => "eta",
+                Self::FLPiecePrio => "f_l_piece_prio",
+                Self::ForceStart => "force_start",
+                Self::Hash => "hash",
+                Self::Private => "private",
+                Self::LastActivity => "last_activity",
+                Self::MagnetUri => "magnet_uri",
+                Self::MaxRatio => "max_ratio",
+                Self::MaxSeedingTime => "max_seeding_time",
+                Self::Name => "name",
+                Self::NumComplete => "num_complete",
+                Self::NumIncomplete => "num_incomplete",
+                Self::NumLeechs => "num_leechs",
+                Self::NumSeeds => "num_seeds",
+                Self::Priority => "priority",
+                Self::Progress => "progress",
+                Self::Ratio => "ratio",
+                Self::RatioLimit => "ratio_limit",
+                Self::Reannounce => "reannounce",
+                Self::SavePath => "save_path",
+                Self::SeedingTime => "seeding_time",
+                Self::SeedingTimeLimit => "seeding_time_limit",
+                Self::SeenComplete => "seen_complete",
+                Self::SeqDl => "seq_dl",
+                Self::Size => "size",
+                Self::State => "state",
+                Self::SuperSeeding => "super_seeding",
+                Self::Tags => "tags",
+                Self::TimeActive => "time_active",
+                Self::TotalSize => "total_size",
+                Self::Tracker => "tracker",
+                Self::UpLimit => "up_limit",
+                Self::Uploaded => "uploaded",
+                Self::UploadedSession => "uploaded_session",
+                Self::Upspeed => "upspeed",
             }
         )
     }
 }
 
 /// Add torrent parameter object
-#[derive(Debug, Default, Builder, Clone)]
+#[derive(Debug, Default, Builder, Clone, Deserialize, Serialize, PartialEq)]
 pub struct AddTorrent {
     /// A list of torrent files or magnet links to be added.
     ///
@@ -289,7 +292,7 @@ impl AddTorrent {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Deserialize, Serialize, Clone, PartialEq)]
 pub enum AddTorrentType {
     Links(Vec<String>),
     Files(Vec<TorrentFile>),
@@ -322,7 +325,7 @@ impl Default for AddTorrentType {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Deserialize, Serialize, Clone, Default, PartialEq)]
 pub struct TorrentFile {
     pub filename: String,
     pub data: Vec<u8>,


### PR DESCRIPTION
> @Mattress237 in https://github.com/Mattress237/qbittorrent-webui-api/issues/20#issuecomment-3172617425:_
> If you want to add more, the `PartialEq` and `Eq` might be nice traits to add. The `Ord/PartialOrd` might be nice for structs like `torrent::Torrent` and `sync::MainData`, just what comes to mind at the top of my head.
> 
> I'm merging this PR, and if you want to add more, you are free to add a new PR.

In this PR I implemented more stuff from the [Rust API Guidelines](https://rust-lang.github.io/api-guidelines/interoperability.html#c-common-traits). I am not sure why you would like to have `PartialOrd` on those structs? I think something like `if torrent1 > torrent2` does not really make sense and if you want to order a `Vec<torrent::Torrent>` I don't think everybody wants to order it by the same key. I think it is better to use `torrents.sort_by_key(|t| t.added_on)` or `torrents.sort_by_key(|t| t.name)` etc. ([docs](https://doc.rust-lang.org/std/primitive.slice.html#method.sort_by_key)).

I think most of the `Default`s are not really useful in normal library usage but I think in unit tests they could be so I added them.