### PR TITLE
fix(popularity): Popularity being null

### DIFF
--- a/src/models/torrent.rs
+++ b/src/models/torrent.rs
@@ -78,7 +78,8 @@ pub struct Torrent {
     /// Number of seeds connected to
     pub num_seeds: i64,
     /// Popularity of the torrent
-    pub popularity: f64,
+    /// See https://www.reddit.com/r/qBittorrent/comments/18t82wi/adding_the_popularity_metric_to_qbittorrent/ for more info.
+    pub popularity: Option<f64>,
     /// Torrent priority. Returns -1 if queuing is disabled or torrent is in seed mode
     pub priority: i64,
     /// True if torrent is from a private tracker (added in 5.0.0)
@@ -203,7 +204,7 @@ impl<'de> Visitor<'de> for TorrentMapVisitor {
             num_incomplete: i64,
             num_leechs: i64,
             num_seeds: i64,
-            popularity: f64,
+            popularity: Option<f64>,
             priority: i64,
             private: Option<bool>,
             progress: f32,


### PR DESCRIPTION
And because there is a reproducible way of causing this, we have to deal with it.
Source:
```json
{
  "added_on":1755936509,
  "amount_left":3276868471,
  "auto_tmm":false,
  "availability":0,
  "category":"Anime",
  "comment":"",
  "completed":0,
  "completion_on":1755936917,
  "content_path":"/home/jellyfin/media/anime/[neoDESU] RPG Real Estate [Season 1] [BD 1080p x265 HEVC OPUS]",
  "dl_limit":0,
  "dlspeed":0,
  "download_path":"",
  "downloaded":0,
  "downloaded_session":0,
  "eta":8640000,
  "f_l_piece_prio":false,
  "force_start":false,
  "has_metadata":true,
  "hash":"4a8304d806c56c31e21cc4236ae24c17f2141d89",
  "inactive_seeding_time_limit":-2,
  "infohash_v1":"4a8304d806c56c31e21cc4236ae24c17f2141d89",
  "infohash_v2":"",
  "last_activity":1756016819,
  "magnet_uri":"magnet:?xt=urn:btih:4a8304d806c56c31e21cc4236ae24c17f2141d89&dn=%5BneoDESU%5D%20RPG%20Real%20Estate%20%5BSeason%201%5D%20%5BBD%201080p%20x265%20HEVC%20OPUS%5D%20RPG%20Fudousan&xl=3276868471&tr=http%3A%2F%2Fnyaa.tracker.wf%3A7777%2Fannounce&tr=udp%3A%2F%2Fopen.stealth.si%3A80%2Fannounce&tr=udp%3A%2F%2Ftracker.opentrackr.org%3A1337%2Fannounce&tr=udp%3A%2F%2Fexodus.desync.com%3A6969%2Fannounce&tr=udp%3A%2F%2Ftracker.torrent.eu.org%3A451%2Fannounce",
  "max_inactive_seeding_time":-1,
  "max_ratio":-1,
  "max_seeding_time":-1,
  "name":"[neoDESU] RPG Real Estate [Season 1] [BD 1080p x265 HEVC OPUS] RPG Fudousan",
  "num_complete":0,
  "num_incomplete":10,
  "num_leechs":0,
  "num_seeds":0,
  "popularity":null,
  "priority":90,
  "private":false,
  "progress":0,
  "ratio":-1,
  "ratio_limit":-2,
  "reannounce":0,
  "root_path":"/home/jellyfin/media/anime/[neoDESU] RPG Real Estate [Season 1] [BD 1080p x265 HEVC OPUS]",
  "save_path":"/home/jellyfin/media/anime",
  "seeding_time":80453,
  "seeding_time_limit":-2,
  "seen_complete":1755947806,
  "seq_dl":false,
  "size":3276868471,
  "state":"missingFiles",
  "super_seeding":false,
  "tags":"Favourites",
  "time_active":80442,
  "total_size":3276868471,
  "tracker":"http://nyaa.tracker.wf:7777/announce",
  "trackers_count":5,
  "up_limit":0,
  "uploaded":1851193012,
  "uploaded_session":0,
  "upspeed":0
}
```

How to reproduce:
- Fully download torrent
- remove torrent but keep files (optional, or just use a different device)
- Add torrent back to qbitt, but with the files already there. Hence the `Download(global) is 0B`
- Ping API when **no files exists**

This does make it annoying, another field requiring an `.unwrap()` to use. But because there is a chance, we kinda have to deal with it...