### PR TITLE
Custom generic serd::deserializer for handling cases where JSON returns null

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 mod client;
 mod error;
+pub(crate) mod utiles;
 
 /// Data object models.
 pub mod models;

--- a/src/models/torrent.rs
+++ b/src/models/torrent.rs
@@ -7,6 +7,7 @@ use serde::{
 use serde_repr::{Deserialize_repr, Serialize_repr};
 
 use crate::parameters::TorrentState;
+use crate::utiles::deserializers;
 
 /// Torrent info response object
 #[derive(Debug, Deserialize, Serialize, Clone, Default, PartialEq)]
@@ -78,6 +79,7 @@ pub struct Torrent {
     /// Number of seeds connected to
     pub num_seeds: i64,
     /// Popularity of the torrent
+    #[serde(deserialize_with = "deserializers::from_null_to_default")]
     pub popularity: f64,
     /// Torrent priority. Returns -1 if queuing is disabled or torrent is in seed mode
     pub priority: i64,

--- a/src/utiles/deserializers/mod.rs
+++ b/src/utiles/deserializers/mod.rs
@@ -1,0 +1,101 @@
+use serde::{Deserialize, Deserializer};
+
+/// This generic function handles deserialization for any type `T` that
+/// can be deserialized from a JSON number and has a default value.
+#[allow(dead_code)]
+pub fn from_option<'de, D, T>(deserializer: D) -> Result<T, D::Error>
+where
+    D: Deserializer<'de>,
+    T: Deserialize<'de> + Default,
+{
+    let value = Option::<T>::deserialize(deserializer)?;
+
+    Ok(value.unwrap_or_default())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde::Deserialize;
+    use serde_json::{self, json};
+
+    #[derive(Deserialize, Debug, PartialEq)]
+    struct TestData<T>
+    where
+        T: for<'a> Deserialize<'a> + PartialEq + Default,
+    {
+        #[serde(deserialize_with = "from_option")]
+        value: T,
+    }
+
+    #[derive(Deserialize, Debug, PartialEq, Default)]
+    enum TestEnum {
+        One,
+        #[default]
+        Two,
+        Tree,
+    }
+
+    #[test]
+    fn test_i64_from_null() {
+        let data = json!({ "value": null });
+        let result: TestData<i64> = serde_json::from_value(data).unwrap();
+        assert_eq!(result.value, 0);
+    }
+
+    #[test]
+    fn test_i64_from_number() {
+        let data = json!({ "value": 123 });
+        let result: TestData<i64> = serde_json::from_value(data).unwrap();
+        assert_eq!(result.value, 123);
+    }
+
+    #[test]
+    fn test_f64_from_null() {
+        let data = json!({ "value": null });
+        let result: TestData<f64> = serde_json::from_value(data).unwrap();
+        assert_eq!(result.value, 0.0);
+    }
+
+    #[test]
+    fn test_f64_from_number() {
+        let data = json!({ "value": 45.67 });
+        let result: TestData<f64> = serde_json::from_value(data).unwrap();
+        assert_eq!(result.value, 45.67);
+    }
+
+    #[test]
+    fn test_bool_from_null() {
+        let data = json!({ "value": null });
+        let result: TestData<bool> = serde_json::from_value(data).unwrap();
+        assert!(!result.value);
+    }
+
+    #[test]
+    fn test_string_from_string() {
+        let data = json!({ "value": "String" });
+        let result: TestData<String> = serde_json::from_value(data).unwrap();
+        assert_eq!(result.value, "String");
+    }
+
+    #[test]
+    fn test_string_from_null() {
+        let data = json!({ "value": null });
+        let result: TestData<String> = serde_json::from_value(data).unwrap();
+        assert_eq!(result.value, "");
+    }
+
+    #[test]
+    fn test_enum_from_value() {
+        let data = json!({ "value": "One" });
+        let result: TestData<TestEnum> = serde_json::from_value(data).unwrap();
+        assert_eq!(result.value, TestEnum::One);
+    }
+
+    #[test]
+    fn test_enum_from_null() {
+        let data = json!({ "value": null });
+        let result: TestData<TestEnum> = serde_json::from_value(data).unwrap();
+        assert_eq!(result.value, TestEnum::Two);
+    }
+}

--- a/src/utiles/deserializers/mod.rs
+++ b/src/utiles/deserializers/mod.rs
@@ -1,9 +1,17 @@
 use serde::{Deserialize, Deserializer};
 
-/// This generic function handles deserialization for any type `T` that
-/// can be deserialized from a JSON number and has a default value.
-#[allow(dead_code)]
-pub fn from_option<'de, D, T>(deserializer: D) -> Result<T, D::Error>
+/// Deserializes a field from a JSON value that might be `null`.
+///
+/// This function is intended to be used with the `#[serde(deserialize_with = "")]`
+/// attribute. It deserializes a value of a generic type `T`. If the JSON value
+/// is `null`, it returns the default value for `T`. Otherwise, it attempts to
+/// deserialize the value normally.
+///
+/// # Type Parameters
+///
+/// * `T`: The target type to deserialize to. This type must implement
+///   `serde::Deserialize` and `std::default::Default`.
+pub fn from_null_to_default<'de, D, T>(deserializer: D) -> Result<T, D::Error>
 where
     D: Deserializer<'de>,
     T: Deserialize<'de> + Default,
@@ -24,7 +32,7 @@ mod tests {
     where
         T: for<'a> Deserialize<'a> + PartialEq + Default,
     {
-        #[serde(deserialize_with = "from_option")]
+        #[serde(deserialize_with = "from_null_to_default")]
         value: T,
     }
 

--- a/src/utiles/mod.rs
+++ b/src/utiles/mod.rs
@@ -1,0 +1,1 @@
+pub mod deserializers;


### PR DESCRIPTION
A `serde::Deserializer` for situations where `null` might be returned from JSON responses. In some rare edge cases, `popularity` for torrents might return `null`. 

The `from_option()` function is generic and accepts all types that implement `Deserialize + Default` and returns the type's default value in the case of `null` 

This is meant as a suggestion for an alternative to make an `Option` field for the `popularity` value on torrents.

ref #27 as the original PR