### PR TITLE
Remove mut from as much as possible

### DIFF
--- a/src/client/application.rs
+++ b/src/client/application.rs
@@ -101,8 +101,7 @@ impl super::Api {
     /// [official documentation](https://github.com/qbittorrent/qBittorrent/wiki/WebUI-API-(qBittorrent-5.0)#set-application-preferences)
     ///
     pub async fn set_preferences(&self, preferences: Preferences) -> Result<(), Error> {
-        let mut form = multipart::Form::new();
-        form = form.text("json", serde_json::to_string(&preferences)?);
+        let form = multipart::Form::new().text("json", serde_json::to_string(&preferences)?);
 
         self._post("app/setPreferences")
             .await?
@@ -163,8 +162,7 @@ impl super::Api {
     /// * `cookies` - A list of cookies to be set.
     ///
     pub async fn set_cookies(&self, cookies: Vec<Cookie>) -> Result<(), Error> {
-        let mut form = multipart::Form::new();
-        form = form.text("cookies", serde_json::to_string(&cookies)?);
+        let form = multipart::Form::new().text("cookies", serde_json::to_string(&cookies)?);
 
         self._post("app/setCookies")
             .await?

--- a/src/client/log.rs
+++ b/src/client/log.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 use crate::{
     error::Error,
     models::{LogItem, LogPeers, LogType},
@@ -20,35 +22,14 @@ impl super::Api {
         last_known_id: Option<i64>,
         log_types: Option<Vec<LogType>>,
     ) -> Result<Vec<LogItem>, Error> {
-        let mut query = vec![];
+        let mut query = HashMap::new();
         if let Some(last_known_id) = last_known_id {
-            query.push(("last_known_id", last_known_id.to_string()));
+            query.insert("last_known_id".to_string(), last_known_id.to_string());
         }
-        let mut normal = false;
-        let mut info = false;
-        let mut warning = false;
-        let mut critical = false;
         if let Some(log_types) = log_types {
-            for log_type in log_types {
-                match log_type {
-                    LogType::Normal => normal = true,
-                    LogType::Info => info = true,
-                    LogType::Warning => warning = true,
-                    LogType::Critical => critical = true,
-                }
-            }
-        }
-        if normal {
-            query.push(("normal", true.to_string()));
-        }
-        if info {
-            query.push(("info", true.to_string()));
-        }
-        if warning {
-            query.push(("warning", true.to_string()));
-        }
-        if critical {
-            query.push(("critical", true.to_string()));
+            log_types.iter().for_each(|log_type| {
+                query.insert(log_type.to_string(), "true".to_string());
+            });
         }
 
         let log = self
@@ -75,9 +56,9 @@ impl super::Api {
     /// * `last_known_id` - Exclude messages with "message id" <= `last_known_id` (default: `-1`)
     ///
     pub async fn peer_log(&self, last_known_id: Option<i64>) -> Result<Vec<LogPeers>, Error> {
-        let mut query = vec![];
-        if let Some(id) = last_known_id {
-            query.push(("last_known_id", id));
+        let mut query = HashMap::new();
+        if let Some(last_known_id) = last_known_id {
+            query.insert("last_known_id".to_string(), last_known_id.to_string());
         }
 
         let log = self

--- a/src/client/rss.rs
+++ b/src/client/rss.rs
@@ -17,8 +17,7 @@ impl super::Api {
     /// * `path` - Full path of added folder. Use `\\` instead of `/` as the delimiter. (e.g. "The Pirate Bay\\Top100")
     ///
     pub async fn rss_add_folder(&self, path: &str) -> Result<(), Error> {
-        let mut form = multipart::Form::new();
-        form = form.text("path", path.to_string());
+        let form = multipart::Form::new().text("path", path.to_string());
 
         self._post("rss/addFolder")
             .await?
@@ -39,13 +38,9 @@ impl super::Api {
     /// * `path` - Full path of added feed. Use `\\` instead of `/` as the delimiter. (e.g. "The Pirate Bay\\Top100")
     ///
     pub async fn rss_add_feed(&self, feed_url: &str, path: Option<&str>) -> Result<(), Error> {
-        let mut form = multipart::Form::new();
-        form = form.text("url", feed_url.to_string());
-        if let Some(path) = path {
-            form = form.text("path", path.to_string());
-        } else {
-            form = form.text("path", "".to_string());
-        }
+        let form = multipart::Form::new()
+            .text("url", feed_url.to_string())
+            .text("path", path.unwrap_or_default().to_string());
 
         self._post("rss/addFeed")
             .await?
@@ -67,8 +62,7 @@ impl super::Api {
     /// * `path` - Full path of removed item. Use `\\` instead of `/` as the delimiter. (e.g. "The Pirate Bay\\Top100")
     ///
     pub async fn rss_remove_item(&self, path: &str) -> Result<(), Error> {
-        let mut form = multipart::Form::new();
-        form = form.text("path", path.to_string());
+        let form = multipart::Form::new().text("path", path.to_string());
 
         self._post("rss/removeItem")
             .await?
@@ -91,9 +85,9 @@ impl super::Api {
     /// * `dest_path` - New full path of item. Use `\\` instead of `/` as the delimiter. (e.g. "The Pirate Bay")
     ///
     pub async fn rss_move_item(&self, item_path: &str, dest_path: &str) -> Result<(), Error> {
-        let mut form = multipart::Form::new();
-        form = form.text("itemPath", item_path.to_string());
-        form = form.text("destPath", dest_path.to_string());
+        let form = multipart::Form::new()
+            .text("itemPath", item_path.to_string())
+            .text("destPath", dest_path.to_string());
 
         self._post("rss/moveItem")
             .await?
@@ -149,8 +143,7 @@ impl super::Api {
     /// * `article_id` - ID of article
     ///
     pub async fn rss_mark_as_read(&self, path: &str, article_id: Option<u64>) -> Result<(), Error> {
-        let mut form = multipart::Form::new();
-        form = form.text("path", path.to_string());
+        let mut form = multipart::Form::new().text("path", path.to_string());
         if let Some(article_id) = article_id {
             form = form.text("articleId", article_id.to_string());
         }
@@ -175,8 +168,7 @@ impl super::Api {
     /// * `item_path` - Current full path of item. Use `\\` instead of `/` as the delimiter. (e.g. "The Pirate Bay\\Top100")
     ///
     pub async fn rss_refresh_item(&self, item_path: &str) -> Result<(), Error> {
-        let mut form = multipart::Form::new();
-        form = form.text("itemPath", item_path.to_string());
+        let form = multipart::Form::new().text("itemPath", item_path.to_string());
 
         self._post("rss/refreshItem")
             .await?
@@ -197,9 +189,9 @@ impl super::Api {
     /// * `def` - rule definition
     ///
     pub async fn rss_set_rule(&self, name: &str, def: RssRule) -> Result<(), Error> {
-        let mut form = multipart::Form::new();
-        form = form.text("ruleName", name.to_string());
-        form = form.text("ruleDef", serde_json::to_string(&def)?);
+        let form = multipart::Form::new()
+            .text("ruleName", name.to_string())
+            .text("ruleDef", serde_json::to_string(&def)?);
 
         self._post("rss/setRule")
             .await?
@@ -220,9 +212,9 @@ impl super::Api {
     /// * `new_name` - New rule name (e.g. "The Punisher")
     ///
     pub async fn rss_rename_rule(&self, name: &str, new_name: &str) -> Result<(), Error> {
-        let mut form = multipart::Form::new();
-        form = form.text("ruleName", name.to_string());
-        form = form.text("newRuleName", new_name.to_string());
+        let form = multipart::Form::new()
+            .text("ruleName", name.to_string())
+            .text("newRuleName", new_name.to_string());
 
         self._post("rss/renameRule")
             .await?
@@ -242,8 +234,7 @@ impl super::Api {
     /// * `name` - Rule name (e.g. "Punisher")
     ///
     pub async fn rss_remove_rule(&self, name: &str) -> Result<(), Error> {
-        let mut form = multipart::Form::new();
-        form = form.text("ruleName", name.to_string());
+        let form = multipart::Form::new().text("ruleName", name.to_string());
 
         self._post("rss/removeRule")
             .await?

--- a/src/client/search.rs
+++ b/src/client/search.rs
@@ -23,10 +23,10 @@ impl super::Api {
         plugins: &str,
         category: &str,
     ) -> Result<u64, Error> {
-        let mut form = multipart::Form::new();
-        form = form.text("pattern", pattern.to_string());
-        form = form.text("plugins", plugins.to_string());
-        form = form.text("category", category.to_string());
+        let form = multipart::Form::new()
+            .text("pattern", pattern.to_string())
+            .text("plugins", plugins.to_string())
+            .text("category", category.to_string());
 
         let json: serde_json::Value = self
             ._post("search/start")
@@ -52,8 +52,7 @@ impl super::Api {
     /// * `id` - ID of the search job
     ///
     pub async fn search_stop(&self, id: u64) -> Result<(), Error> {
-        let mut form = multipart::Form::new();
-        form = form.text("id", id.to_string());
+        let form = multipart::Form::new().text("id", id.to_string());
 
         self._post("search/stop")
             .await?
@@ -138,8 +137,7 @@ impl super::Api {
     /// * `id` - The unique identifier of the search job.
     ///
     pub async fn search_delete(&self, id: u64) -> Result<(), Error> {
-        let mut form = multipart::Form::new();
-        form = form.text("id", id.to_string());
+        let form = multipart::Form::new().text("id", id.to_string());
 
         self._post("search/delete")
             .await?
@@ -176,8 +174,7 @@ impl super::Api {
     /// * `sources` - List of Url and file path of the plugin to install.
     ///
     pub async fn search_install_plugin(&self, sources: Vec<&str>) -> Result<(), Error> {
-        let mut form = multipart::Form::new();
-        form = form.text("sources", sources.join("|"));
+        let form = multipart::Form::new().text("sources", sources.join("|"));
 
         self._post("search/installPlugin")
             .await?
@@ -197,8 +194,7 @@ impl super::Api {
     /// * `names` - List of names for torrents to uninstall.
     ///
     pub async fn search_uninstall_plugin(&self, names: Vec<&str>) -> Result<(), Error> {
-        let mut form = multipart::Form::new();
-        form = form.text("names", names.join("|"));
+        let form = multipart::Form::new().text("names", names.join("|"));
 
         self._post("search/uninstallPlugin")
             .await?
@@ -218,9 +214,9 @@ impl super::Api {
     /// * `names` - List of names for torrents to enable.
     ///
     pub async fn search_enable_plugin(&self, names: Vec<&str>, enable: bool) -> Result<(), Error> {
-        let mut form = multipart::Form::new();
-        form = form.text("names", names.join("|"));
-        form = form.text("enable", enable.to_string());
+        let form = multipart::Form::new()
+            .text("names", names.join("|"))
+            .text("enable", enable.to_string());
 
         self._post("search/enablePlugin")
             .await?

--- a/src/client/torrent.rs
+++ b/src/client/torrent.rs
@@ -230,8 +230,7 @@ impl super::Api {
     /// * `hashes` - Hashes list of torrents to stop.
     ///
     pub async fn stop(&self, hashes: Vec<&str>) -> Result<(), Error> {
-        let mut form = multipart::Form::new();
-        form = form.text("hashes", hashes.join("|"));
+        let form = multipart::Form::new().text("hashes", hashes.join("|"));
 
         self._post("torrents/stop")
             .await?
@@ -252,8 +251,7 @@ impl super::Api {
     /// * `hashes` - Hashes list of torrents to start.
     ///
     pub async fn start(&self, hashes: Vec<&str>) -> Result<(), Error> {
-        let mut form = multipart::Form::new();
-        form = form.text("hashes", hashes.join("|"));
+        let form = multipart::Form::new().text("hashes", hashes.join("|"));
 
         self._post("torrents/start")
             .await?
@@ -276,9 +274,9 @@ impl super::Api {
     ///   otherwise has no effect.
     ///
     pub async fn delete(&self, hashes: Vec<&str>, delete_files: bool) -> Result<(), Error> {
-        let mut form = multipart::Form::new();
-        form = form.text("hashes", hashes.join("|"));
-        form = form.text("deleteFiles", delete_files.to_string());
+        let form = multipart::Form::new()
+            .text("hashes", hashes.join("|"))
+            .text("deleteFiles", delete_files.to_string());
 
         self._post("torrents/delete")
             .await?
@@ -299,8 +297,7 @@ impl super::Api {
     /// * `hashes` - Hashes list of torrents to recheck.
     ///
     pub async fn recheck(&self, hashes: Vec<&str>) -> Result<(), Error> {
-        let mut form = multipart::Form::new();
-        form = form.text("hashes", hashes.join("|"));
+        let form = multipart::Form::new().text("hashes", hashes.join("|"));
 
         self._post("torrents/recheck")
             .await?
@@ -321,8 +318,7 @@ impl super::Api {
     /// * `hashes` - Hashes list of torrents to reannounce.
     ///
     pub async fn reannounce(&self, hashes: Vec<&str>) -> Result<(), Error> {
-        let mut form = multipart::Form::new();
-        form = form.text("hashes", hashes.join("|"));
+        let form = multipart::Form::new().text("hashes", hashes.join("|"));
 
         self._post("torrents/reannounce")
             .await?
@@ -371,15 +367,16 @@ impl super::Api {
             }
         };
 
-        form = form.text("skip_checking", params.skip_checking.to_string());
-        form = form.text("paused", params.paused.to_string());
-        form = form.text("autoTMM", params.auto_tmm.to_string());
-        form = form.text("sequentialDownload", params.sequential_download.to_string());
-        form = form.text("contentLayout", params.content_layout.to_string());
-        form = form.text(
-            "firstLastPiecePrio",
-            params.first_last_piece_prio.to_string(),
-        );
+        form = form
+            .text("skip_checking", params.skip_checking.to_string())
+            .text("paused", params.paused.to_string())
+            .text("autoTMM", params.auto_tmm.to_string())
+            .text("sequentialDownload", params.sequential_download.to_string())
+            .text("contentLayout", params.content_layout.to_string())
+            .text(
+                "firstLastPiecePrio",
+                params.first_last_piece_prio.to_string(),
+            );
         if let Some(savepath) = params.savepath {
             form = form.text("savepath", savepath);
         }
@@ -425,9 +422,9 @@ impl super::Api {
     /// * `urls` - Trackers urls to add.
     ///
     pub async fn add_trackers_to_torrent(&self, hash: &str, urls: Vec<&str>) -> Result<(), Error> {
-        let mut form = multipart::Form::new();
-        form = form.text("hash", hash.to_string());
-        form = form.text("urls", urls.join("%0A"));
+        let form = multipart::Form::new()
+            .text("hash", hash.to_string())
+            .text("urls", urls.join("%0A"));
 
         self._post("torrents/addTrackers")
             .await?
@@ -455,10 +452,10 @@ impl super::Api {
         orig_url: &str,
         new_url: &str,
     ) -> Result<(), Error> {
-        let mut form = multipart::Form::new();
-        form = form.text("hash", hash.to_string());
-        form = form.text("origUrl", orig_url.to_string());
-        form = form.text("newUrl", new_url.to_string());
+        let form = multipart::Form::new()
+            .text("hash", hash.to_string())
+            .text("origUrl", orig_url.to_string())
+            .text("newUrl", new_url.to_string());
 
         self._post("torrents/editTracker")
             .await?
@@ -484,9 +481,9 @@ impl super::Api {
         hash: &str,
         urls: Vec<&str>,
     ) -> Result<(), Error> {
-        let mut form = multipart::Form::new();
-        form = form.text("hash", hash.to_string());
-        form = form.text("urls", urls.join("|"));
+        let form = multipart::Form::new()
+            .text("hash", hash.to_string())
+            .text("urls", urls.join("|"));
 
         self._post("torrents/removeTrackers")
             .await?
@@ -508,9 +505,9 @@ impl super::Api {
     /// * `peers` - The peer to add. Each peer is a colon-separated `host:port`.
     ///
     pub async fn add_peers(&self, hashes: Vec<&str>, peers: Vec<&str>) -> Result<(), Error> {
-        let mut form = multipart::Form::new();
-        form = form.text("hashes", hashes.join("|"));
-        form = form.text("peers", peers.join("|"));
+        let form = multipart::Form::new()
+            .text("hashes", hashes.join("|"))
+            .text("peers", peers.join("|"));
 
         self._post("torrents/addPeers")
             .await?
@@ -532,12 +529,7 @@ impl super::Api {
     ///   If `None` all torrents are selected.
     ///
     pub async fn increase_priority(&self, hashes: Option<Vec<&str>>) -> Result<(), Error> {
-        let mut form = multipart::Form::new();
-        if let Some(hashes) = hashes {
-            form = form.text("hashes", hashes.join("|"));
-        } else {
-            form = form.text("hashes", "all".to_string());
-        }
+        let form = multipart::Form::new().text("hashes", hashes.unwrap_or(vec!["all"]).join("|"));
 
         self._post("torrents/increasePrio")
             .await?
@@ -559,12 +551,7 @@ impl super::Api {
     ///   If `None` all torrents are selected.
     ///
     pub async fn decrease_priority(&self, hashes: Option<Vec<&str>>) -> Result<(), Error> {
-        let mut form = multipart::Form::new();
-        if let Some(hashes) = hashes {
-            form = form.text("hashes", hashes.join("|"));
-        } else {
-            form = form.text("hashes", "all".to_string());
-        }
+        let form = multipart::Form::new().text("hashes", hashes.unwrap_or(vec!["all"]).join("|"));
 
         self._post("torrents/decreasePrio")
             .await?
@@ -586,12 +573,7 @@ impl super::Api {
     ///   If `None` all torrents are selected.
     ///
     pub async fn max_priority(&self, hashes: Option<Vec<&str>>) -> Result<(), Error> {
-        let mut form = multipart::Form::new();
-        if let Some(hashes) = hashes {
-            form = form.text("hashes", hashes.join("|"));
-        } else {
-            form = form.text("hashes", "all".to_string());
-        }
+        let form = multipart::Form::new().text("hashes", hashes.unwrap_or(vec!["all"]).join("|"));
 
         self._post("torrents/topPrio")
             .await?
@@ -613,12 +595,7 @@ impl super::Api {
     ///   If `None` all torrents are selected.
     ///
     pub async fn min_priority(&self, hashes: Option<Vec<&str>>) -> Result<(), Error> {
-        let mut form = multipart::Form::new();
-        if let Some(hashes) = hashes {
-            form = form.text("hashes", hashes.join("|"));
-        } else {
-            form = form.text("hashes", "all".to_string());
-        }
+        let form = multipart::Form::new().text("hashes", hashes.unwrap_or(vec!["all"]).join("|"));
 
         self._post("torrents/bottomPrio")
             .await?
@@ -646,17 +623,17 @@ impl super::Api {
         file_ids: Vec<u64>,
         priority: FilePriority,
     ) -> Result<(), Error> {
-        let mut form = multipart::Form::new();
-        form = form.text("hash", hash.to_string());
-        form = form.text(
-            "id",
-            file_ids
-                .iter()
-                .map(|&num| num.to_string())
-                .collect::<Vec<String>>()
-                .join("|"),
-        );
-        form = form.text("priority", serde_json::to_string(&priority)?);
+        let form = multipart::Form::new()
+            .text("hash", hash.to_string())
+            .text(
+                "id",
+                file_ids
+                    .iter()
+                    .map(|&num| num.to_string())
+                    .collect::<Vec<String>>()
+                    .join("|"),
+            )
+            .text("priority", serde_json::to_string(&priority)?);
 
         self._post("torrents/filePrio")
             .await?
@@ -681,12 +658,7 @@ impl super::Api {
         &self,
         hashes: Option<Vec<&str>>,
     ) -> Result<HashMap<String, u64>, Error> {
-        let mut query = vec![];
-        if let Some(hashes) = hashes {
-            query.push(("hashes", hashes.join("|")));
-        } else {
-            query.push(("hashes", "all".to_string()));
-        }
+        let query = vec![("hashes", hashes.unwrap_or(vec!["all"]).join("|"))];
 
         let limites = self
             ._get("torrents/downloadLimit")
@@ -716,13 +688,9 @@ impl super::Api {
         hashes: Option<Vec<&str>>,
         limit: u64,
     ) -> Result<(), Error> {
-        let mut form = multipart::Form::new();
-        if let Some(hashes) = hashes {
-            form = form.text("hashes", hashes.join("|"));
-        } else {
-            form = form.text("hashes", "all".to_string());
-        }
-        form = form.text("limit", limit.to_string());
+        let form = multipart::Form::new()
+            .text("hashes", hashes.unwrap_or(vec!["all"]).join("|"))
+            .text("limit", limit.to_string());
 
         self._post("torrents/setDownloadLimit")
             .await?
@@ -757,18 +725,14 @@ impl super::Api {
         seeding_time_limit: i64,
         inactive_seeding_time_limit: i64,
     ) -> Result<(), Error> {
-        let mut form = multipart::Form::new();
-        if let Some(hashes) = hashes {
-            form = form.text("hashes", hashes.join("|"));
-        } else {
-            form = form.text("hashes", "all".to_string());
-        }
-        form = form.text("ratioLimit", ratio_limit.to_string());
-        form = form.text("seedingTimeLimit", seeding_time_limit.to_string());
-        form = form.text(
-            "inactiveSeedingTimeLimit",
-            inactive_seeding_time_limit.to_string(),
-        );
+        let form = multipart::Form::new()
+            .text("hashes", hashes.unwrap_or(vec!["all"]).join("|"))
+            .text("ratioLimit", ratio_limit.to_string())
+            .text("seedingTimeLimit", seeding_time_limit.to_string())
+            .text(
+                "inactiveSeedingTimeLimit",
+                inactive_seeding_time_limit.to_string(),
+            );
 
         self._post("torrents/setShareLimits")
             .await?
@@ -793,12 +757,7 @@ impl super::Api {
         &self,
         hashes: Option<Vec<&str>>,
     ) -> Result<HashMap<String, i64>, Error> {
-        let mut query = vec![];
-        if let Some(hashes) = hashes {
-            query.push(("hashes", hashes.join("|")));
-        } else {
-            query.push(("hashes", "all".to_string()));
-        }
+        let query = vec![("hashes", hashes.unwrap_or(vec!["all"]).join("|"))];
 
         let limites = self
             ._get("torrents/uploadLimit")
@@ -828,13 +787,9 @@ impl super::Api {
         hashes: Option<Vec<&str>>,
         limit: u64,
     ) -> Result<(), Error> {
-        let mut form = multipart::Form::new();
-        if let Some(hashes) = hashes {
-            form = form.text("hashes", hashes.join("|"));
-        } else {
-            form = form.text("hashes", "all".to_string());
-        }
-        form = form.text("limit", limit.to_string());
+        let form = multipart::Form::new()
+            .text("hashes", hashes.unwrap_or(vec!["all"]).join("|"))
+            .text("limit", limit.to_string());
 
         self._post("torrents/setUploadLimit")
             .await?
@@ -861,13 +816,9 @@ impl super::Api {
         hashes: Option<Vec<&str>>,
         location: &str,
     ) -> Result<(), Error> {
-        let mut form = multipart::Form::new();
-        if let Some(hashes) = hashes {
-            form = form.text("hashes", hashes.join("|"));
-        } else {
-            form = form.text("hashes", "all".to_string());
-        }
-        form = form.text("location", location.to_string());
+        let form = multipart::Form::new()
+            .text("hashes", hashes.unwrap_or(vec!["all"]).join("|"))
+            .text("location", location.to_string());
 
         self._post("torrents/setLocation")
             .await?
@@ -889,9 +840,9 @@ impl super::Api {
     /// * `name` - Location to download the torrent to.
     ///
     pub async fn set_name(&self, hash: &str, name: &str) -> Result<(), Error> {
-        let mut form = multipart::Form::new();
-        form = form.text("hash", hash.to_string());
-        form = form.text("name", name.to_string());
+        let form = multipart::Form::new()
+            .text("hash", hash.to_string())
+            .text("name", name.to_string());
 
         self._post("torrents/setLocation")
             .await?
@@ -918,13 +869,9 @@ impl super::Api {
         hashes: Option<Vec<&str>>,
         category: &str,
     ) -> Result<(), Error> {
-        let mut form = multipart::Form::new();
-        if let Some(hashes) = hashes {
-            form = form.text("hashes", hashes.join("|"));
-        } else {
-            form = form.text("hashes", "all".to_string());
-        }
-        form = form.text("category", category.to_string());
+        let form = multipart::Form::new()
+            .text("hashes", hashes.unwrap_or(vec!["all"]).join("|"))
+            .text("category", category.to_string());
 
         self._post("torrents/setCategory")
             .await?
@@ -963,9 +910,9 @@ impl super::Api {
     /// * `save_path` - Path to download torrents for the category.
     ///
     pub async fn create_category(&self, category: &str, save_path: &str) -> Result<(), Error> {
-        let mut form = multipart::Form::new();
-        form = form.text("category", category.to_string());
-        form = form.text("savePath", save_path.to_string());
+        let form = multipart::Form::new()
+            .text("category", category.to_string())
+            .text("savePath", save_path.to_string());
 
         self._post("torrents/createCategory")
             .await?
@@ -987,9 +934,9 @@ impl super::Api {
     /// * `save_path` - Path to download torrents for the category.
     ///
     pub async fn edit_category(&self, category: &str, save_path: &str) -> Result<(), Error> {
-        let mut form = multipart::Form::new();
-        form = form.text("category", category.to_string());
-        form = form.text("savePath", save_path.to_string());
+        let form = multipart::Form::new()
+            .text("category", category.to_string())
+            .text("savePath", save_path.to_string());
 
         self._post("torrents/editCategory")
             .await?
@@ -1010,8 +957,7 @@ impl super::Api {
     /// * `categories` - List of category names to remove.
     ///
     pub async fn remove_categories(&self, categories: Vec<&str>) -> Result<(), Error> {
-        let mut form = multipart::Form::new();
-        form = form.text("categories", categories.join("\n"));
+        let form = multipart::Form::new().text("categories", categories.join("\n"));
 
         self._post("torrents/removeCategories")
             .await?
@@ -1034,13 +980,9 @@ impl super::Api {
     /// * `tags` - List of names for the tags you want to set.
     ///
     pub async fn add_tags(&self, hashes: Option<Vec<&str>>, tags: Vec<&str>) -> Result<(), Error> {
-        let mut form = multipart::Form::new();
-        if let Some(hashes) = hashes {
-            form = form.text("hashes", hashes.join("|"));
-        } else {
-            form = form.text("hashes", "all".to_string());
-        }
-        form = form.text("tags", tags.join(","));
+        let form = multipart::Form::new()
+            .text("hashes", hashes.unwrap_or(vec!["all"]).join("|"))
+            .text("tags", tags.join(","));
 
         self._post("torrents/addTags")
             .await?
@@ -1067,13 +1009,9 @@ impl super::Api {
         hashes: Option<Vec<&str>>,
         tags: Vec<&str>,
     ) -> Result<(), Error> {
-        let mut form = multipart::Form::new();
-        if let Some(hashes) = hashes {
-            form = form.text("hashes", hashes.join("|"));
-        } else {
-            form = form.text("hashes", "all".to_string());
-        }
-        form = form.text("tags", tags.join(","));
+        let form = multipart::Form::new()
+            .text("hashes", hashes.unwrap_or(vec!["all"]).join("|"))
+            .text("tags", tags.join(","));
 
         self._post("torrents/removeTags")
             .await?
@@ -1111,8 +1049,7 @@ impl super::Api {
     /// * `tags` - List of tags to create.
     ///
     pub async fn create_tags(&self, tags: Vec<&str>) -> Result<(), Error> {
-        let mut form = multipart::Form::new();
-        form = form.text("tags", tags.join(","));
+        let form = multipart::Form::new().text("tags", tags.join(","));
 
         self._post("torrents/createTags")
             .await?
@@ -1133,8 +1070,7 @@ impl super::Api {
     /// * `tags` - List of tags to delete.
     ///
     pub async fn torrent_delete_tags(&self, tags: Vec<&str>) -> Result<(), Error> {
-        let mut form = multipart::Form::new();
-        form = form.text("tags", tags.join(","));
+        let form = multipart::Form::new().text("tags", tags.join(","));
 
         self._post("torrents/deleteTags")
             .await?
@@ -1161,13 +1097,9 @@ impl super::Api {
         hashes: Option<Vec<&str>>,
         enable: bool,
     ) -> Result<(), Error> {
-        let mut form = multipart::Form::new();
-        if let Some(hashes) = hashes {
-            form = form.text("hashes", hashes.join("|"));
-        } else {
-            form = form.text("hashes", "all".to_string());
-        }
-        form = form.text("enable", enable.to_string());
+        let form = multipart::Form::new()
+            .text("hashes", hashes.unwrap_or(vec!["all"]).join("|"))
+            .text("enable", enable.to_string());
 
         self._post("torrents/setAutoManagement")
             .await?
@@ -1189,12 +1121,7 @@ impl super::Api {
     ///   If `None` all torrents are selected.
     ///
     pub async fn toggle_sequential_download(&self, hashes: Option<Vec<&str>>) -> Result<(), Error> {
-        let mut form = multipart::Form::new();
-        if let Some(hashes) = hashes {
-            form = form.text("hashes", hashes.join("|"));
-        } else {
-            form = form.text("hashes", "all".to_string());
-        }
+        let form = multipart::Form::new().text("hashes", hashes.unwrap_or(vec!["all"]).join("|"));
 
         self._post("torrents/toggleSequentialDownload")
             .await?
@@ -1216,12 +1143,7 @@ impl super::Api {
     ///   If `None` all torrents are selected.
     ///
     pub async fn toggle_first_last_priority(&self, hashes: Option<Vec<&str>>) -> Result<(), Error> {
-        let mut form = multipart::Form::new();
-        if let Some(hashes) = hashes {
-            form = form.text("hashes", hashes.join("|"));
-        } else {
-            form = form.text("hashes", "all".to_string());
-        }
+        let form = multipart::Form::new().text("hashes", hashes.unwrap_or(vec!["all"]).join("|"));
 
         self._post("torrents/toggleFirstLastPiecePrio")
             .await?
@@ -1248,13 +1170,9 @@ impl super::Api {
         hashes: Option<Vec<&str>>,
         enable: bool,
     ) -> Result<(), Error> {
-        let mut form = multipart::Form::new();
-        if let Some(hashes) = hashes {
-            form = form.text("hashes", hashes.join("|"));
-        } else {
-            form = form.text("hashes", "all".to_string());
-        }
-        form = form.text("value", enable.to_string());
+        let form = multipart::Form::new()
+            .text("hashes", hashes.unwrap_or(vec!["all"]).join("|"))
+            .text("value", enable.to_string());
 
         self._post("torrents/setForceStart")
             .await?
@@ -1281,13 +1199,9 @@ impl super::Api {
         hashes: Option<Vec<&str>>,
         enable: bool,
     ) -> Result<(), Error> {
-        let mut form = multipart::Form::new();
-        if let Some(hashes) = hashes {
-            form = form.text("hashes", hashes.join("|"));
-        } else {
-            form = form.text("hashes", "all".to_string());
-        }
-        form = form.text("value", enable.to_string());
+        let form = multipart::Form::new()
+            .text("hashes", hashes.unwrap_or(vec!["all"]).join("|"))
+            .text("value", enable.to_string());
 
         self._post("torrents/setSuperSeeding")
             .await?
@@ -1315,10 +1229,10 @@ impl super::Api {
         old_path: &str,
         new_path: &str,
     ) -> Result<(), Error> {
-        let mut form = multipart::Form::new();
-        form = form.text("hash", hash.to_string());
-        form = form.text("oldPath", old_path.to_string());
-        form = form.text("newPath", new_path.to_string());
+        let form = multipart::Form::new()
+            .text("hash", hash.to_string())
+            .text("oldPath", old_path.to_string())
+            .text("newPath", new_path.to_string());
 
         self._post("torrents/renameFile")
             .await?
@@ -1346,10 +1260,10 @@ impl super::Api {
         old_path: &str,
         new_path: &str,
     ) -> Result<(), Error> {
-        let mut form = multipart::Form::new();
-        form = form.text("hash", hash.to_string());
-        form = form.text("oldPath", old_path.to_string());
-        form = form.text("newPath", new_path.to_string());
+        let form = multipart::Form::new()
+            .text("hash", hash.to_string())
+            .text("oldPath", old_path.to_string())
+            .text("newPath", new_path.to_string());
 
         self._post("torrents/renameFolder")
             .await?

--- a/src/client/transfer.rs
+++ b/src/client/transfer.rs
@@ -80,8 +80,7 @@ impl super::Api {
     /// * `limit` - The global download speed limit to set in bytes/second. `0` if no limit.
     ///
     pub async fn set_global_download_limit(&self, limit: u64) -> Result<(), Error> {
-        let mut form = multipart::Form::new();
-        form = form.text("limit", limit.to_string());
+        let form = multipart::Form::new().text("limit", limit.to_string());
 
         self._post("transfer/setDownloadLimit")
             .await?
@@ -119,8 +118,7 @@ impl super::Api {
     /// * `limit` - The global upload speed limit to set in bytes/second. `0` if no limit.
     ///
     pub async fn set_global_upload_limit(&self, limit: u64) -> Result<(), Error> {
-        let mut form = multipart::Form::new();
-        form = form.text("limit", limit.to_string());
+        let form = multipart::Form::new().text("limit", limit.to_string());
 
         self._post("transfer/setUploadLimit")
             .await?
@@ -141,8 +139,7 @@ impl super::Api {
     /// * `peers` - The peer to ban, or multiple peers. Each peer is a colon-separated `host:port`
     ///
     pub async fn peers_ban(&self, peers: Vec<String>) -> Result<(), Error> {
-        let mut form = multipart::Form::new();
-        form = form.text("peers", peers.join("|"));
+        let form = multipart::Form::new().text("peers", peers.join("|"));
 
         self._post("transfer/banPeers")
             .await?

--- a/src/models/log.rs
+++ b/src/models/log.rs
@@ -1,3 +1,5 @@
+use std::fmt::Display;
+
 use serde::{Deserialize, Serialize};
 use serde_repr::{Deserialize_repr, Serialize_repr};
 
@@ -28,6 +30,21 @@ pub enum LogType {
     Info = 2,
     Warning = 4,
     Critical = 8,
+}
+
+impl Display for LogType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "{}",
+            match self {
+                LogType::Normal => "normal",
+                LogType::Info => "info",
+                LogType::Warning => "warning",
+                LogType::Critical => "critical",
+            }
+        )
+    }
 }
 
 /// Peer log item data object


### PR DESCRIPTION
The `other half` of #26.

ignoring the whole macro situtation, this is the code split out that is actually worth something. (I basically recreated this section just for this PR for simplicity sake)

Basically, most times where `let mut form` or `let mut query` has been used, if possible have been removed. I don't actually know if this helps a very tiny bit with performance or not, It just seems nicer this way and makes use of the builder aspect more often.

What i don't like however, is the one-liners
```diff
- let mut form = multipart::Form::new();
- form = form.text("path", path.to_string());
+ let form = multipart::Form::new().text("path", path.to_string());
```
Just as it makes it a bit harder to read due to no clear gap (other than a tiny `.`)

There are also small optimisations using `.unwrap_or()` in places of `if let some` which just reduces code and allows better readability imo

The places that have not been affected are places where theres some kind of condition preventing it from being a simple replacement. 

Whilst on the topic, maybe its worth trying to make everything the same type? A Hashmap for example. `.query` seems to be quite forgiving with the type passed into it, (hashmaps or vecs) so having some kind of conseisenticy might be worth doing.