### PR TITLE
Fix: The one test that keeps breaking (and some slight changes)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ bytes = "1.10.1"
 
 [dev-dependencies]
 dotenv = "0.15.0"
+rand = "0.9.2"
 
 [lints.clippy]
 uninlined_format_args = "allow"

--- a/src/models/creator.rs
+++ b/src/models/creator.rs
@@ -94,6 +94,24 @@ impl From<String> for TorrentCreatorTask {
     }
 }
 
+impl PartialEq<TorrentCreatorTask> for String {
+    fn eq(&self, other: &TorrentCreatorTask) -> bool {
+        *self == other.task_id
+    }
+}
+
+impl PartialEq<TorrentCreatorTask> for &str {
+    fn eq(&self, other: &TorrentCreatorTask) -> bool {
+        *self == other.task_id
+    }
+}
+
+impl PartialEq<TorrentCreatorTask> for &String {
+    fn eq(&self, other: &TorrentCreatorTask) -> bool {
+        **self == other.task_id
+    }
+}
+
 /// How big the chunks of pieces can be in Bytes
 ///
 /// Custom values are allowed, however pre-made values have also been included.

--- a/src/models/creator.rs
+++ b/src/models/creator.rs
@@ -94,6 +94,12 @@ impl From<String> for TorrentCreatorTask {
     }
 }
 
+impl Display for TorrentCreatorTask {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.task_id)
+    }
+}
+
 impl PartialEq<TorrentCreatorTask> for String {
     fn eq(&self, other: &TorrentCreatorTask) -> bool {
         *self == other.task_id

--- a/tests/application/get_directory_contents.rs
+++ b/tests/application/get_directory_contents.rs
@@ -6,7 +6,7 @@ use qbit::models::DirMode;
 #[tokio::test]
 #[ignore = "Test hits api endpoint"]
 pub async fn list_directory() {
-    let folder = create_test_data();
+    let folder = create_test_data(None);
     let client = login_default_client().await;
     let contents = client
         .get_directory_contents(&folder, &DirMode::default())
@@ -20,7 +20,7 @@ pub async fn list_directory() {
 #[tokio::test]
 #[ignore = "Test hits api endpoint"]
 pub async fn list_directory_files() {
-    let folder = create_test_data();
+    let folder = create_test_data(None);
     let client = login_default_client().await;
     let contents = client
         .get_directory_contents(&folder, &DirMode::Files)
@@ -34,7 +34,7 @@ pub async fn list_directory_files() {
 #[tokio::test]
 #[ignore = "Test hits api endpoint"]
 pub async fn list_directory_dirs() {
-    let folder = create_test_data();
+    let folder = create_test_data(None);
     let client = login_default_client().await;
     let contents = client
         .get_directory_contents(&folder, &DirMode::Dirs)

--- a/tests/mod.rs
+++ b/tests/mod.rs
@@ -95,7 +95,11 @@ pub fn create_random_name() -> Option<String> {
 pub fn create_test_data(random_name: Option<String>) -> String {
     dotenv().ok();
     // persionally did not want to have to do this, but `/tmp` can cause some issues so...
-    let folder = env::var("temp_dir").unwrap();
+    let folder = format!(
+        "{}{}",
+        env::var("temp_dir").unwrap(),
+        random_name.clone().unwrap_or_default()
+    );
 
     if !fs::exists(&folder).unwrap() {
         fs::create_dir(&folder).unwrap_or_default();

--- a/tests/mod.rs
+++ b/tests/mod.rs
@@ -4,7 +4,7 @@ use qbit::{
     models::{Torrent, TorrentCreatorBuilder, TorrentCreatorTask},
     parameters::AddTorrentBuilder,
 };
-use rand::{Rng, distr::Alphabetic, rngs};
+use rand::{Rng, distr::Alphabetic};
 use std::{env, fs, path};
 
 pub mod application;

--- a/tests/mod.rs
+++ b/tests/mod.rs
@@ -1,9 +1,10 @@
 use dotenv::dotenv;
 use qbit::{
     Api,
-    models::{TorrentCreatorBuilder, TorrentCreatorTask, Torrent},
+    models::{Torrent, TorrentCreatorBuilder, TorrentCreatorTask},
     parameters::AddTorrentBuilder,
 };
+use rand::{Rng, distr::Alphabetic, rngs};
 use std::{env, fs, path};
 
 pub mod application;
@@ -81,7 +82,17 @@ pub async fn get_debian_torrent(client: &Api) -> Option<Torrent> {
         .map(|t| t.to_owned())
 }
 
-pub fn create_test_data() -> String {
+pub fn create_random_name() -> Option<String> {
+    Some(
+        rand::rng()
+            .sample_iter(&Alphabetic)
+            .take(7)
+            .map(char::from)
+            .collect::<String>(),
+    )
+}
+
+pub fn create_test_data(random_name: Option<String>) -> String {
     dotenv().ok();
     // persionally did not want to have to do this, but `/tmp` can cause some issues so...
     let folder = env::var("temp_dir").unwrap();
@@ -94,7 +105,7 @@ pub fn create_test_data() -> String {
     }
 
     fs::write(
-        format!("{folder}/dummy.txt"),
+        format!("{folder}/dummy{}.txt", random_name.unwrap_or_default()),
         "This is a dummy file. You are a dummy for downloading this file.",
     )
     .expect("Failed to write dummy file");
@@ -102,15 +113,21 @@ pub fn create_test_data() -> String {
     path::absolute(folder).unwrap().display().to_string()
 }
 
-pub async fn create_dummy_torrent(client: &Api) -> Result<TorrentCreatorTask, qbit::Error> {
-    let folder = create_test_data();
+pub async fn create_dummy_torrent(
+    client: &Api,
+    random_name: Option<String>,
+) -> Result<TorrentCreatorTask, qbit::Error> {
+    let folder = create_test_data(random_name.clone());
     let torrent = TorrentCreatorBuilder::default()
         .source_path(&folder)
         .start_seeding(true)
         .private(true)
         .comment("Dummy comment for a dummy torrent")
         .source("https://example.com/dummy")
-        .torrent_file_path(format!("{folder}_data/dummy.torrent"))
+        .torrent_file_path(format!(
+            "{folder}_data/dummy{}.torrent",
+            random_name.unwrap_or_default()
+        ))
         .build()
         .expect("Failed to build torrent creator");
 

--- a/tests/torrents/creator.rs
+++ b/tests/torrents/creator.rs
@@ -32,7 +32,11 @@ async fn get_torrent_file() {
     create_dummy_torrent(&client).await.unwrap();
 
     let folder = env::var("temp_dir").unwrap();
-    let data = fs::read(format!("{folder}_data/dummy.torrent")).unwrap();
+    let path = format!("{folder}_data/dummy.torrent");
+    if !fs::exists(&path).unwrap() {
+        std::thread::sleep(std::time::Duration::from_secs(5));
+    }
+    let data = fs::read(&path).unwrap();
 
     let list = client.list_tasks().await.unwrap();
     for item in list.iter() {

--- a/tests/torrents/creator.rs
+++ b/tests/torrents/creator.rs
@@ -26,7 +26,7 @@ async fn list_tasks() {
     let result = create_dummy_torrent(&client, random_name).await.unwrap();
     let list = client.list_tasks().await.unwrap();
     assert!(!list.is_empty());
-    assert!(list.iter().any(|t| t.task_id == result.task_id));
+    assert!(list.iter().any(|t| t.task_id == result));
 }
 
 /// Tests to see that upon the torrent being finished, it is the same as the information we have in the dummy file.
@@ -93,13 +93,13 @@ async fn delete_created_task() {
     let task_id = create_dummy_torrent(&client, random_name).await.unwrap();
     let list = client.list_tasks().await.unwrap();
     assert!(!list.is_empty());
-    assert!(list.iter().any(|t| t.task_id == task_id.task_id));
+    assert!(list.iter().any(|t| t.task_id == task_id));
     client
         .delete_task(&task_id)
         .await
         .expect("Failed to delete task");
     let list = client.list_tasks().await.unwrap();
-    assert!(!list.iter().any(|t| t.task_id == task_id.task_id));
+    assert!(!list.iter().any(|t| t.task_id == task_id));
 }
 
 /// Test to check failed to create errors

--- a/tests/torrents/creator.rs
+++ b/tests/torrents/creator.rs
@@ -33,6 +33,7 @@ async fn list_tasks() {
 async fn get_torrent_file() {
     let client = login_default_client().await;
     let task = create_dummy_torrent(&client).await.unwrap();
+    println!("task: {}", task);
     let mut list = client.list_tasks().await.unwrap();
 
     // This should hopefully let the torrent finish creating before attempting to do other stuff.
@@ -45,6 +46,7 @@ async fn get_torrent_file() {
         .status
         != TaskStatus::Finished
     {
+        println!("{:?}", list);
         if limit == 0 {
             panic!("Torrent has not finished creating after ~ 10 seconds of checking.");
         }

--- a/tests/torrents/creator.rs
+++ b/tests/torrents/creator.rs
@@ -46,7 +46,10 @@ async fn get_torrent_file() {
         .status
         != TaskStatus::Finished
     {
-        println!("{:?}", list);
+        println!(
+            "{:?}",
+            list.iter().filter(|v| v.task_id == task).next().unwrap()
+        );
         if limit == 0 {
             panic!("Torrent has not finished creating after ~ 10 seconds of checking.");
         }
@@ -103,11 +106,8 @@ async fn make_failed_task() {
         .expect("Failed to build torrent creator");
 
     let id = client.create_task(&torrent).await.unwrap();
+    let result = client.get_task_file(id).await;
 
-    let result = client.get_task_file(id.to_string()).await;
-
-    // delete the task in attempt to clean up for other stuff.
-    client.delete_task(&id).await.unwrap();
     assert!(result.is_err());
     if let Err(Error::Http409(_e)) = result {
         assert!(true);

--- a/tests/torrents/creator.rs
+++ b/tests/torrents/creator.rs
@@ -104,7 +104,10 @@ async fn make_failed_task() {
 
     let id = client.create_task(&torrent).await.unwrap();
 
-    let result = client.get_task_file(id).await;
+    let result = client.get_task_file(id.to_string()).await;
+
+    // delete the task in attempt to clean up for other stuff.
+    client.delete_task(&id).await.unwrap();
     assert!(result.is_err());
     if let Err(Error::Http409(_e)) = result {
         assert!(true);

--- a/tests/torrents/creator.rs
+++ b/tests/torrents/creator.rs
@@ -64,7 +64,11 @@ async fn get_torrent_file() {
         limit -= 1;
     }
 
-    let folder = env::var("temp_dir").unwrap();
+    let folder = format!(
+        "{}{}",
+        env::var("temp_dir").unwrap(),
+        random_name.clone().unwrap()
+    );
     let path = format!("{folder}_data/dummy{}.torrent", random_name.unwrap());
     let data = fs::read(&path).unwrap();
 

--- a/tests/torrents/creator.rs
+++ b/tests/torrents/creator.rs
@@ -3,7 +3,7 @@ use qbit::{
     models::{TaskStatus, TorrentCreatorBuilder},
 };
 
-use crate::{create_dummy_torrent, login_default_client};
+use crate::{create_dummy_torrent, create_random_name, login_default_client};
 use std::{env, fs};
 
 /// This test makes sure that the endpoint can create a dummy task.
@@ -11,7 +11,8 @@ use std::{env, fs};
 #[ignore = "Test hits api endpoint"]
 async fn create_task() {
     let client = login_default_client().await;
-    let result = create_dummy_torrent(&client).await;
+    let random_name = create_random_name();
+    let result = create_dummy_torrent(&client, random_name).await;
 
     assert!(result.is_ok());
 }
@@ -21,7 +22,8 @@ async fn create_task() {
 #[ignore = "Test hits api endpoint"]
 async fn list_tasks() {
     let client = login_default_client().await;
-    let result = create_dummy_torrent(&client).await.unwrap();
+    let random_name = create_random_name();
+    let result = create_dummy_torrent(&client, random_name).await.unwrap();
     let list = client.list_tasks().await.unwrap();
     assert!(!list.is_empty());
     assert!(list.iter().any(|t| t.task_id == result.task_id));
@@ -32,7 +34,10 @@ async fn list_tasks() {
 #[ignore = "Test hits api endpoint"]
 async fn get_torrent_file() {
     let client = login_default_client().await;
-    let task = create_dummy_torrent(&client).await.unwrap();
+    let random_name = create_random_name();
+    let task = create_dummy_torrent(&client, random_name.clone())
+        .await
+        .unwrap();
     println!("task: {}", task);
     let mut list = client.list_tasks().await.unwrap();
 
@@ -60,7 +65,7 @@ async fn get_torrent_file() {
     }
 
     let folder = env::var("temp_dir").unwrap();
-    let path = format!("{folder}_data/dummy.torrent");
+    let path = format!("{folder}_data/dummy{}.torrent", random_name.unwrap());
     let data = fs::read(&path).unwrap();
 
     for item in list.iter() {
@@ -80,7 +85,8 @@ async fn get_torrent_file() {
 #[ignore = "Test hits api endpoint"]
 async fn delete_created_task() {
     let client = login_default_client().await;
-    let task_id = create_dummy_torrent(&client).await.unwrap();
+    let random_name = create_random_name();
+    let task_id = create_dummy_torrent(&client, random_name).await.unwrap();
     let list = client.list_tasks().await.unwrap();
     assert!(!list.is_empty());
     assert!(list.iter().any(|t| t.task_id == task_id.task_id));


### PR DESCRIPTION
## Test fixes
Hopefully fixes the occasional occurrence of `test torrents::creator::get_torrent_file ... FAILED`

I believe this test is failing due to another test getting there beforehand. Creating and seeding the dummy file. (It's how i get the qbitt error message of `Failed to start seeding` appear)

To fix this, the introduction of the dev dependency `rand` is used to make sure each test can have their own unique version of the dummy file (unless luck is not on our side and rand somehow generates the same thing twice and breaks thing, although really low chance)

I've made sure to re-run the same test 5 times (shown here: https://github.com/dragmine149/qbittorrent-webui-api/actions/runs/17299511706) just to be absolutely certain that this issue won't happen again.

As per #30 we don't really want any tests failing if we're going to release a new major version do we?

## Stringify-task
This section might be worth another PR but added basic ability for `TorrentCreatorTask` to compare with Strings. I would have done it more like this originally, i just couldn't be bothered working out how to deal with the rename issue. (and some other things i've forgotten about)

This change just allows for nicer comparision as shown below
```diff
let task_id = create_dummy_torrent(&client, random_name).await.unwrap();
let list = client.list_tasks().await.unwrap();
+ assert!(list.iter().any(|t| t.task_id == task_id));
- assert!(list.iter().any(|t| t.task_id == task_id.task_id));
```
I do see it potentially introducing some confusion and might just need a better implantation method overall.