### PR TITLE
Basic examples in method docblocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,41 @@
+[![Crates.io version](https://img.shields.io/crates/v/qbit)](https://crates.io/crates/qbit)
+[![Github repo](https://img.shields.io/badge/Github-Repo-orange?logo=github)](https://github.com/Mattress237/qbittorrent-webui-api)
+[![docs.rs](https://img.shields.io/docsrs/qbit)](https://docs.rs/qbit)
+[![Rust](https://img.shields.io/badge/Rust-stable-brightgreen?logo=rust)](https://www.rust-lang.org/)
+
 # Qbittorrent WebUI Api
 
-Rust wrapper for Qbittorrent WebUI API
+Asynchronous Rust wrapper for Qbittorrent Web API, supporting all documented endpoints.
 
-Supported Qbittorrent version: `5.0`
+Supported Qbittorrent version: `5.1`
 
-[WebUI 5.0 documentation](<https://github.com/qbittorrent/qBittorrent/wiki/WebUI-API-(qBittorrent-5.0)>)
+# Usage
+
+Add it using cargo:
+```
+cargo add qbit
+```
+
+Add it manualy:
+``` toml
+[dependencies]
+qbit = "0.1"
+```
+
+Basic usage to get all torrents:
+``` rust
+use qbit::API;
+use qbit::Credentials;
+
+let cred = Credentials::new("username", "secret_password");
+let client = API::new_login("http://qBittorrent.server:6969", cred).await.unwrap();
+
+let torrents = client.torrents(None).await.unwrap();
+```
 
 ## Implemented
+
+[WebUI 5.0 documentation](<https://github.com/qbittorrent/qBittorrent/wiki/WebUI-API-(qBittorrent-5.0)>)
 
 ### Authentication
 

--- a/src/client/application.rs
+++ b/src/client/application.rs
@@ -14,6 +14,23 @@ impl super::Api {
     ///
     /// [official documentation](https://github.com/qbittorrent/qBittorrent/wiki/WebUI-API-(qBittorrent-5.0)#get-application-version)
     ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use qbit::{Api, Credentials};
+    ///
+    /// #[tokio::main]
+    /// async fn main() {
+    ///     let credentials = Credentials::new("username", "password");
+    ///     let client = Api::new_login("url", credentials)
+    ///         .await
+    ///         .unwrap();
+    ///
+    ///     let version = client.version().await.unwrap();
+    ///
+    ///     println!("{}", version);
+    /// }
+    /// ```
     pub async fn version(&self) -> Result<String, Error> {
         let version = self
             ._get("app/version")
@@ -33,6 +50,23 @@ impl super::Api {
     ///
     /// [official documentation](https://github.com/qbittorrent/qBittorrent/wiki/WebUI-API-(qBittorrent-5.0)#get-api-version)
     ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use qbit::{Api, Credentials};
+    ///
+    /// #[tokio::main]
+    /// async fn main() {
+    ///     let credentials = Credentials::new("username", "password");
+    ///     let client = Api::new_login("url", credentials)
+    ///         .await
+    ///         .unwrap();
+    ///
+    ///     let version = client.webapi_version().await.unwrap();
+    ///
+    ///     println!("{}", version);
+    /// }
+    /// ```
     pub async fn webapi_version(&self) -> Result<String, Error> {
         let version = self
             ._get("app/webapiVersion")
@@ -50,6 +84,23 @@ impl super::Api {
     ///
     /// [official documentation](https://github.com/qbittorrent/qBittorrent/wiki/WebUI-API-(qBittorrent-5.0)#get-build-info)
     ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use qbit::{Api, Credentials};
+    ///
+    /// #[tokio::main]
+    /// async fn main() {
+    ///     let credentials = Credentials::new("username", "password");
+    ///     let client = Api::new_login("url", credentials)
+    ///         .await
+    ///         .unwrap();
+    ///
+    ///     let build = client.build_info().await.unwrap();
+    ///
+    ///     println!("{:#?}", build);
+    /// }
+    /// ```
     pub async fn build_info(&self) -> Result<BuildInfo, Error> {
         let build_info = self
             ._get("app/buildInfo")
@@ -67,6 +118,21 @@ impl super::Api {
     ///
     /// [official documentation](https://github.com/qbittorrent/qBittorrent/wiki/WebUI-API-(qBittorrent-5.0)#shutdown-application)
     ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use qbit::{Api, Credentials};
+    ///
+    /// #[tokio::main]
+    /// async fn main() {
+    ///     let credentials = Credentials::new("username", "password");
+    ///     let client = Api::new_login("url", credentials)
+    ///         .await
+    ///         .unwrap();
+    ///
+    ///     client.shutdown().await.unwrap();
+    /// }
+    /// ```
     pub async fn shutdown(&self) -> Result<(), Error> {
         self._post("app/shutdown")
             .await?
@@ -83,8 +149,25 @@ impl super::Api {
     ///
     /// [official documentation](https://github.com/qbittorrent/qBittorrent/wiki/WebUI-API-(qBittorrent-5.0)#get-application-preferences)
     ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use qbit::{Api, Credentials};
+    ///
+    /// #[tokio::main]
+    /// async fn main() {
+    ///     let credentials = Credentials::new("username", "password");
+    ///     let client = Api::new_login("url", credentials)
+    ///         .await
+    ///         .unwrap();
+    ///
+    ///     let preferences = client.preferences().await.unwrap();
+    ///
+    ///     println!("{:#?}", preferences);
+    /// }
+    /// ```
     pub async fn preferences(&self) -> Result<Preferences, Error> {
-        let build_info = self
+        let preferences = self
             ._get("app/preferences")
             .await?
             .send()
@@ -93,13 +176,33 @@ impl super::Api {
             .json::<Preferences>()
             .await?;
 
-        Ok(build_info)
+        Ok(preferences)
     }
 
     /// Set application preferences
     ///
     /// [official documentation](https://github.com/qbittorrent/qBittorrent/wiki/WebUI-API-(qBittorrent-5.0)#set-application-preferences)
     ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use qbit::{Api, Credentials};
+    /// use qbit::models::Preferences;
+    ///
+    /// #[tokio::main]
+    /// async fn main() {
+    ///     let credentials = Credentials::new("username", "password");
+    ///     let client = Api::new_login("url", credentials)
+    ///         .await
+    ///         .unwrap();
+    ///
+    ///     let preferences = Preferences::default();
+    ///
+    ///     let resulte = client.set_preferences(preferences).await;
+    ///
+    ///     assert!(resulte.is_ok());
+    /// }
+    /// ```
     pub async fn set_preferences(&self, preferences: Preferences) -> Result<(), Error> {
         let form = multipart::Form::new().text("json", serde_json::to_string(&preferences)?);
 
@@ -117,6 +220,23 @@ impl super::Api {
     ///
     /// [official documentation](https://github.com/qbittorrent/qBittorrent/wiki/WebUI-API-(qBittorrent-5.0)#get-default-save-path)
     ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use qbit::{Api, Credentials};
+    ///
+    /// #[tokio::main]
+    /// async fn main() {
+    ///     let credentials = Credentials::new("username", "password");
+    ///     let client = Api::new_login("url", credentials)
+    ///         .await
+    ///         .unwrap();
+    ///
+    ///     let save_path = client.default_save_path().await.unwrap();
+    ///
+    ///     println!("{}", save_path);
+    /// }
+    /// ```
     pub async fn default_save_path(&self) -> Result<String, Error> {
         let preferences = self
             ._get("app/defaultSavePath")
@@ -136,6 +256,25 @@ impl super::Api {
     ///
     /// [official documentation](https://github.com/qbittorrent/qBittorrent/wiki/WebUI-API-(qBittorrent-5.0)#get-cookies)
     ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use qbit::{Api, Credentials};
+    ///
+    /// #[tokio::main]
+    /// async fn main() {
+    ///     let credentials = Credentials::new("username", "password");
+    ///     let client = Api::new_login("url", credentials)
+    ///         .await
+    ///         .unwrap();
+    ///
+    ///     let cookies = client.cookies().await.unwrap();
+    ///
+    ///     for cookie in cookies {
+    ///         println!("{:?}", cookie);
+    ///     }
+    /// }
+    /// ```
     pub async fn cookies(&self) -> Result<Vec<Cookie>, Error> {
         let cookies = self
             ._get("app/cookies")
@@ -161,6 +300,25 @@ impl super::Api {
     ///
     /// * `cookies` - A list of cookies to be set.
     ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use qbit::{Api, Credentials};
+    /// use qbit::models::Cookie;
+    ///
+    /// #[tokio::main]
+    /// async fn main() {
+    ///     let credentials = Credentials::new("username", "password");
+    ///     let client = Api::new_login("url", credentials)
+    ///         .await
+    ///         .unwrap();
+    ///
+    ///     let cookie = Cookie::default();
+    ///     let result = client.cookies().await;
+    ///
+    ///     assert!(result.is_ok());
+    /// }
+    /// ```
     pub async fn set_cookies(&self, cookies: Vec<Cookie>) -> Result<(), Error> {
         let form = multipart::Form::new().text("cookies", serde_json::to_string(&cookies)?);
 
@@ -175,6 +333,29 @@ impl super::Api {
     }
 
     /// List the contents of the directory. (Yes this is an endpoint)
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use qbit::{Api, Credentials};
+    /// use qbit::models::DirMode;
+    ///
+    /// #[tokio::main]
+    /// async fn main() {
+    ///     let credentials = Credentials::new("username", "password");
+    ///     let client = Api::new_login("url", credentials)
+    ///         .await
+    ///         .unwrap();
+    ///
+    ///     let contents = client.get_directory_contents("dir_path", &DirMode::All)
+    ///         .await
+    ///         .unwrap();
+    ///
+    ///     for item in contents {
+    ///         println!("{}", item);
+    ///     }
+    /// }
+    /// ```
     pub async fn get_directory_contents(
         &self,
         dir: &str,

--- a/src/client/authentication.rs
+++ b/src/client/authentication.rs
@@ -11,6 +11,19 @@ impl super::Api {
     /// * `url` - The base URL of the API service.
     /// * `credentials` - The credentials to use for authentication.
     ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use qbit::{Api, Credentials};
+    ///
+    /// #[tokio::main]
+    /// async fn main() {
+    ///     let credentials = Credentials::new("username", "password");
+    ///     let client = Api::new_login("url", credentials)
+    ///         .await
+    ///         .unwrap();
+    /// }
+    /// ```
     pub async fn new_login(url: &str, credentials: Credentials) -> Result<Self, Error> {
         let mut api = Self::new(url)?;
 
@@ -30,6 +43,18 @@ impl super::Api {
     /// * `username` - The username for authentication.
     /// * `password` - The password for authentication.
     ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use qbit::Api;
+    ///
+    /// #[tokio::main]
+    /// async fn main() {
+    ///     let client = Api::new_login_username_password("url", "username", "password")
+    ///         .await
+    ///         .unwrap();
+    /// }
+    /// ```
     pub async fn new_login_username_password(
         url: &str,
         username: impl Into<String>,
@@ -51,6 +76,22 @@ impl super::Api {
     /// * `credentials` - The credentials to use for authentication.
     /// * `force` - If true, forces a login even if already logged in.
     ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use qbit::{Api, Credentials};
+    ///
+    /// #[tokio::main]
+    /// async fn main() {
+    ///     let credentials = Credentials::new("username", "password");
+    ///     let mut client = Api::new_login("url", credentials)
+    ///         .await
+    ///         .unwrap();
+    ///
+    ///     // relogin the client
+    ///     client.login(true).await.unwrap();
+    /// }
+    /// ```
     pub async fn login(&mut self, force: bool) -> Result<(), Error> {
         // check if already login (aka cookie set)
         if self.state.read().await.as_cookie().is_some() && !force {
@@ -128,6 +169,18 @@ impl super::Api {
     /// * `url` - The base URL of the API service.
     /// * `sid_cookie` - The session ID cookie for authentication.
     ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use qbit::Api;
+    ///
+    /// #[tokio::main]
+    /// async fn main() {
+    ///     let client = Api::new_from_cookie("url", "cookie")
+    ///         .await
+    ///         .unwrap();
+    /// }
+    /// ```
     pub async fn new_from_cookie(url: &str, sid_cookie: impl Into<&str>) -> Result<Self, Error> {
         let mut api = Self::new(url)?;
 
@@ -150,6 +203,20 @@ impl super::Api {
     ///
     /// [official documentation](https://github.com/qbittorrent/qBittorrent/wiki/WebUI-API-(qBittorrent-5.0)#logout)
     ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use qbit::{Api, Credentials};
+    ///
+    /// #[tokio::main]
+    /// async fn main() {
+    ///     let credentials = Credentials::new("username", "password");
+    ///     let client = Api::new_login("url", credentials)
+    ///         .await
+    ///         .unwrap();
+    ///
+    ///     client.logout().await.unwrap();
+    /// }
     pub async fn logout(&self) -> Result<(), Error> {
         self._post("auth/logout")
             .await?

--- a/src/client/authentication.rs
+++ b/src/client/authentication.rs
@@ -217,6 +217,7 @@ impl super::Api {
     ///
     ///     client.logout().await.unwrap();
     /// }
+    /// ```
     pub async fn logout(&self) -> Result<(), Error> {
         self._post("auth/logout")
             .await?

--- a/src/client/creator.rs
+++ b/src/client/creator.rs
@@ -9,6 +9,26 @@ use crate::{
 
 impl super::Api {
     /// Create a task to eventually make a new torrent.
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use qbit::{Api, Credentials};
+    /// use qbit::models::TorrentCreator;
+    ///
+    /// #[tokio::main]
+    /// async fn main() {
+    ///     let credentials = Credentials::new("username", "password");
+    ///     let client = Api::new_login("url", credentials)
+    ///         .await
+    ///         .unwrap();
+    ///
+    ///     let torrent = TorrentCreator::default();
+    ///     let result = client.create_task(&torrent).await;
+    ///
+    ///     assert!(result.is_ok());
+    /// }
+    /// ```
     pub async fn create_task(&self, params: &TorrentCreator) -> Result<TorrentCreatorTask, Error> {
         let mut form = HashMap::new();
         form.insert("sourcePath", params.source_path.clone());
@@ -60,6 +80,26 @@ impl super::Api {
     }
 
     /// List all tasks that have been created before.
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use qbit::{Api, Credentials};
+    ///
+    /// #[tokio::main]
+    /// async fn main() {
+    ///     let credentials = Credentials::new("username", "password");
+    ///     let client = Api::new_login("url", credentials)
+    ///         .await
+    ///         .unwrap();
+    ///
+    ///     let list = client.list_tasks().await.unwrap();
+    ///
+    ///     for item in list {
+    ///         println!("{:?}", item);
+    ///     }
+    /// }
+    /// ```
     pub async fn list_tasks(&self) -> Result<Vec<TorrentCreatorTaskStatus>, Error> {
         Ok(self
             ._get("torrentcreator/status")
@@ -72,6 +112,24 @@ impl super::Api {
     }
 
     /// Get the `.torrent` file for a given task id. (Task must have finished)
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use qbit::{Api, Credentials};
+    ///
+    /// #[tokio::main]
+    /// async fn main() {
+    ///     let credentials = Credentials::new("username", "password");
+    ///     let client = Api::new_login("url", credentials)
+    ///         .await
+    ///         .unwrap();
+    ///
+    ///     let task = client.get_task_file("task_id".to_string()).await.unwrap();
+    ///
+    ///     println!("{:#?}", task);
+    /// }
+    /// ```
     pub async fn get_task_file(
         &self,
         task_id: impl Into<TorrentCreatorTask>,
@@ -99,9 +157,27 @@ impl super::Api {
     }
 
     /// Delete the task with the given id.
-    pub async fn delete_task(&self, task_id: &TorrentCreatorTask) -> Result<(), Error> {
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use qbit::{Api, Credentials};
+    ///
+    /// #[tokio::main]
+    /// async fn main() {
+    ///     let credentials = Credentials::new("username", "password");
+    ///     let client = Api::new_login("url", credentials)
+    ///         .await
+    ///         .unwrap();
+    ///
+    ///     let result = client.delete_task("task_id".to_string()).await;
+    ///
+    ///     assert!(result.is_ok());
+    /// }
+    /// ```
+    pub async fn delete_task(&self, task_id: impl Into<TorrentCreatorTask>) -> Result<(), Error> {
         let mut data = HashMap::new();
-        data.insert("taskID", task_id.task_id.to_owned());
+        data.insert("taskID", task_id.into().task_id.to_owned());
 
         self._post("torrentcreator/deleteTask")
             .await?

--- a/src/client/log.rs
+++ b/src/client/log.rs
@@ -17,6 +17,27 @@ impl super::Api {
     /// * `last_known_id` - Exclude messages with "message id" <= `last_known_id` (default: `-1`)
     /// * `log_types` - List of desierd log types. (default: all)
     ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use qbit::{Api, Credentials};
+    /// use qbit::models::LogType;
+    ///
+    /// #[tokio::main]
+    /// async fn main() {
+    ///     let credentials = Credentials::new("username", "password");
+    ///     let client = Api::new_login("url", credentials)
+    ///         .await
+    ///         .unwrap();
+    ///
+    ///     let types = vec![LogType::Critical, LogType::Warning];
+    ///     let log = client.log(None, Some(types)).await.unwrap();
+    ///
+    ///     for item in log {
+    ///         println!("{:?}", item);
+    ///     }
+    /// }
+    /// ```
     pub async fn log(
         &self,
         last_known_id: Option<i64>,
@@ -55,6 +76,25 @@ impl super::Api {
     ///
     /// * `last_known_id` - Exclude messages with "message id" <= `last_known_id` (default: `-1`)
     ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use qbit::{Api, Credentials};
+    ///
+    /// #[tokio::main]
+    /// async fn main() {
+    ///     let credentials = Credentials::new("username", "password");
+    ///     let client = Api::new_login("url", credentials)
+    ///         .await
+    ///         .unwrap();
+    ///
+    ///     let log = client.peer_log(None).await.unwrap();
+    ///
+    ///     for item in log {
+    ///         println!("{:?}", item);
+    ///     }
+    /// }
+    /// ```
     pub async fn peer_log(&self, last_known_id: Option<i64>) -> Result<Vec<LogPeers>, Error> {
         let mut query = HashMap::new();
         if let Some(last_known_id) = last_known_id {

--- a/src/client/rss.rs
+++ b/src/client/rss.rs
@@ -16,6 +16,23 @@ impl super::Api {
     ///
     /// * `path` - Full path of added folder. Use `\\` instead of `/` as the delimiter. (e.g. "The Pirate Bay\\Top100")
     ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use qbit::{Api, Credentials};
+    ///
+    /// #[tokio::main]
+    /// async fn main() {
+    ///     let credentials = Credentials::new("username", "password");
+    ///     let client = Api::new_login("url", credentials)
+    ///         .await
+    ///         .unwrap();
+    ///
+    ///     let result = client.rss_add_folder("folder").await;
+    ///
+    ///     assert!(result.is_ok());
+    /// }
+    /// ```
     pub async fn rss_add_folder(&self, path: &str) -> Result<(), Error> {
         let form = multipart::Form::new().text("path", path.to_string());
 
@@ -37,6 +54,24 @@ impl super::Api {
     /// * `feed_url` - URL of RSS feed (e.g. "http://thepiratebay.org/rss//top100/200")
     /// * `path` - Full path of added feed. Use `\\` instead of `/` as the delimiter. (e.g. "The Pirate Bay\\Top100")
     ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use qbit::{Api, Credentials};
+    ///
+    /// #[tokio::main]
+    /// async fn main() {
+    ///     let credentials = Credentials::new("username", "password");
+    ///     let client = Api::new_login("url", credentials)
+    ///         .await
+    ///         .unwrap();
+    ///
+    ///     let feed = "http://thepiratebay.org/rss//top100/200";
+    ///     let result = client.rss_add_feed(feed, Some("add\\it\\here")).await;
+    ///
+    ///     assert!(result.is_ok());
+    /// }
+    /// ```
     #[allow(rustdoc::bare_urls)]
     pub async fn rss_add_feed(&self, feed_url: &str, path: Option<&str>) -> Result<(), Error> {
         let form = multipart::Form::new()
@@ -62,6 +97,23 @@ impl super::Api {
     /// # Arguments
     /// * `path` - Full path of removed item. Use `\\` instead of `/` as the delimiter. (e.g. "The Pirate Bay\\Top100")
     ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use qbit::{Api, Credentials};
+    ///
+    /// #[tokio::main]
+    /// async fn main() {
+    ///     let credentials = Credentials::new("username", "password");
+    ///     let client = Api::new_login("url", credentials)
+    ///         .await
+    ///         .unwrap();
+    ///
+    ///     let result = client.rss_remove_item("remove\\this\\item").await;
+    ///
+    ///     assert!(result.is_ok());
+    /// }
+    /// ```
     pub async fn rss_remove_item(&self, path: &str) -> Result<(), Error> {
         let form = multipart::Form::new().text("path", path.to_string());
 
@@ -85,6 +137,23 @@ impl super::Api {
     /// * `item_path` - Current full path of item. Use `\\` instead of `/` as the delimiter. (e.g. "The Pirate Bay\\Top100")
     /// * `dest_path` - New full path of item. Use `\\` instead of `/` as the delimiter. (e.g. "The Pirate Bay")
     ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use qbit::{Api, Credentials};
+    ///
+    /// #[tokio::main]
+    /// async fn main() {
+    ///     let credentials = Credentials::new("username", "password");
+    ///     let client = Api::new_login("url", credentials)
+    ///         .await
+    ///         .unwrap();
+    ///
+    ///     let result = client.rss_move_item("move\\it", "to\\here").await;
+    ///
+    ///     assert!(result.is_ok());
+    /// }
+    /// ```
     pub async fn rss_move_item(&self, item_path: &str, dest_path: &str) -> Result<(), Error> {
         let form = multipart::Form::new()
             .text("itemPath", item_path.to_string())
@@ -113,6 +182,25 @@ impl super::Api {
     /// The `RssFeedCollection` contains detailed information about each RSS feed, including its
     /// articles if `withData` is set to true. `RssFeedCollection` can have nested `RssFeedCollection`
     ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use qbit::{Api, Credentials};
+    ///
+    /// #[tokio::main]
+    /// async fn main() {
+    ///     let credentials = Credentials::new("username", "password");
+    ///     let client = Api::new_login("url", credentials)
+    ///         .await
+    ///         .unwrap();
+    ///
+    ///     let feed = client.rss_items(true).await.unwrap();
+    ///
+    ///     for item in feed {
+    ///         println!("{:?}", item);
+    ///     }
+    /// }
+    /// ```
     pub async fn rss_items(
         &self,
         with_data: bool,
@@ -143,6 +231,23 @@ impl super::Api {
     /// * `path` - Current full path of item. Use `\\` instead of `/` as the delimiter. (e.g. "The Pirate Bay\\Top100")
     /// * `article_id` - ID of article
     ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use qbit::{Api, Credentials};
+    ///
+    /// #[tokio::main]
+    /// async fn main() {
+    ///     let credentials = Credentials::new("username", "password");
+    ///     let client = Api::new_login("url", credentials)
+    ///         .await
+    ///         .unwrap();
+    ///
+    ///     let result = client.rss_mark_as_read("path\\to\\feed", None).await;
+    ///
+    ///     assert!(result.is_ok());
+    /// }
+    /// ```
     pub async fn rss_mark_as_read(&self, path: &str, article_id: Option<u64>) -> Result<(), Error> {
         let mut form = multipart::Form::new().text("path", path.to_string());
         if let Some(article_id) = article_id {
@@ -168,6 +273,23 @@ impl super::Api {
     /// # Arguments
     /// * `item_path` - Current full path of item. Use `\\` instead of `/` as the delimiter. (e.g. "The Pirate Bay\\Top100")
     ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use qbit::{Api, Credentials};
+    ///
+    /// #[tokio::main]
+    /// async fn main() {
+    ///     let credentials = Credentials::new("username", "password");
+    ///     let client = Api::new_login("url", credentials)
+    ///         .await
+    ///         .unwrap();
+    ///
+    ///     let result = client.rss_refresh_item("path\\to\\feed").await;
+    ///
+    ///     assert!(result.is_ok());
+    /// }
+    /// ```
     pub async fn rss_refresh_item(&self, item_path: &str) -> Result<(), Error> {
         let form = multipart::Form::new().text("itemPath", item_path.to_string());
 
@@ -189,6 +311,25 @@ impl super::Api {
     /// * `name` - Rule name (e.g. "Punisher")
     /// * `def` - rule definition
     ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use qbit::{Api, Credentials};
+    /// use qbit::models::RssRule;
+    ///
+    /// #[tokio::main]
+    /// async fn main() {
+    ///     let credentials = Credentials::new("username", "password");
+    ///     let client = Api::new_login("url", credentials)
+    ///         .await
+    ///         .unwrap();
+    ///
+    ///     let rule = RssRule::default();
+    ///     let result = client.rss_set_rule("rule_name", rule).await;
+    ///
+    ///     assert!(result.is_ok());
+    /// }
+    /// ```
     pub async fn rss_set_rule(&self, name: &str, def: RssRule) -> Result<(), Error> {
         let form = multipart::Form::new()
             .text("ruleName", name.to_string())
@@ -212,6 +353,23 @@ impl super::Api {
     /// * `name` - Rule name (e.g. "Punisher")
     /// * `new_name` - New rule name (e.g. "The Punisher")
     ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use qbit::{Api, Credentials};
+    ///
+    /// #[tokio::main]
+    /// async fn main() {
+    ///     let credentials = Credentials::new("username", "password");
+    ///     let client = Api::new_login("url", credentials)
+    ///         .await
+    ///         .unwrap();
+    ///
+    ///     let result = client.rss_rename_rule("old_name", "new_name").await;
+    ///
+    ///     assert!(result.is_ok());
+    /// }
+    /// ```
     pub async fn rss_rename_rule(&self, name: &str, new_name: &str) -> Result<(), Error> {
         let form = multipart::Form::new()
             .text("ruleName", name.to_string())
@@ -234,6 +392,23 @@ impl super::Api {
     /// # Arguments
     /// * `name` - Rule name (e.g. "Punisher")
     ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use qbit::{Api, Credentials};
+    ///
+    /// #[tokio::main]
+    /// async fn main() {
+    ///     let credentials = Credentials::new("username", "password");
+    ///     let client = Api::new_login("url", credentials)
+    ///         .await
+    ///         .unwrap();
+    ///
+    ///     let result = client.rss_remove_rule("rule_name").await;
+    ///
+    ///     assert!(result.is_ok());
+    /// }
+    /// ```
     pub async fn rss_remove_rule(&self, name: &str) -> Result<(), Error> {
         let form = multipart::Form::new().text("ruleName", name.to_string());
 
@@ -251,6 +426,25 @@ impl super::Api {
     ///
     /// [official documentation](https://github.com/qbittorrent/qBittorrent/wiki/WebUI-API-(qBittorrent-5.0)#get-all-auto-downloading-rules)
     ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use qbit::{Api, Credentials};
+    ///
+    /// #[tokio::main]
+    /// async fn main() {
+    ///     let credentials = Credentials::new("username", "password");
+    ///     let client = Api::new_login("url", credentials)
+    ///         .await
+    ///         .unwrap();
+    ///
+    ///     let rules = client.rss_rules().await.unwrap();
+    ///
+    ///     for rule in rules {
+    ///         println!("{:?}", rule);
+    ///     }
+    /// }
+    /// ```
     pub async fn rss_rules(&self) -> Result<HashMap<String, RssRule>, Error> {
         let rules = self
             ._get("rss/rules")
@@ -271,6 +465,25 @@ impl super::Api {
     /// # Arguments
     /// * `name` - Rule name (e.g. "Linux")
     ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use qbit::{Api, Credentials};
+    ///
+    /// #[tokio::main]
+    /// async fn main() {
+    ///     let credentials = Credentials::new("username", "password");
+    ///     let client = Api::new_login("url", credentials)
+    ///         .await
+    ///         .unwrap();
+    ///
+    ///     let articles = client.rss_rules_articles("rule_name").await.unwrap();
+    ///
+    ///     for article in articles {
+    ///         println!("{:?}", article);
+    ///     }
+    /// }
+    /// ```
     pub async fn rss_rules_articles(
         &self,
         name: &str,

--- a/src/client/rss.rs
+++ b/src/client/rss.rs
@@ -37,6 +37,7 @@ impl super::Api {
     /// * `feed_url` - URL of RSS feed (e.g. "http://thepiratebay.org/rss//top100/200")
     /// * `path` - Full path of added feed. Use `\\` instead of `/` as the delimiter. (e.g. "The Pirate Bay\\Top100")
     ///
+    #[allow(rustdoc::bare_urls)]
     pub async fn rss_add_feed(&self, feed_url: &str, path: Option<&str>) -> Result<(), Error> {
         let form = multipart::Form::new()
             .text("url", feed_url.to_string())

--- a/src/client/search.rs
+++ b/src/client/search.rs
@@ -17,6 +17,25 @@ impl super::Api {
     /// * `category` - Categories to limit your search to (e.g. "legittorrents").
     ///   Available categories depend on the specified plugins. Also supports `all`
     ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use qbit::{Api, Credentials};
+    ///
+    /// #[tokio::main]
+    /// async fn main() {
+    ///     let credentials = Credentials::new("username", "password");
+    ///     let client = Api::new_login("url", credentials)
+    ///         .await
+    ///         .unwrap();
+    ///
+    ///     let id = client.search_start("Ubuntu 18.04", "legittorrents", "all")
+    ///         .await
+    ///         .unwrap();
+    ///
+    ///        println!("id: {}", id);
+    /// }
+    /// ```
     pub async fn search_start(
         &self,
         pattern: &str,
@@ -51,6 +70,23 @@ impl super::Api {
     /// # Arguments
     /// * `id` - ID of the search job
     ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use qbit::{Api, Credentials};
+    ///
+    /// #[tokio::main]
+    /// async fn main() {
+    ///     let credentials = Credentials::new("username", "password");
+    ///     let client = Api::new_login("url", credentials)
+    ///         .await
+    ///         .unwrap();
+    ///
+    ///     let result = client.search_stop(1337).await;
+    ///
+    ///     assert!(result.is_ok());
+    /// }
+    /// ```
     pub async fn search_stop(&self, id: u64) -> Result<(), Error> {
         let form = multipart::Form::new().text("id", id.to_string());
 
@@ -72,6 +108,27 @@ impl super::Api {
     ///
     /// * `id` - ID of the search job. If `None`, all search jobs are returned
     ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use qbit::{Api, Credentials};
+    ///
+    /// #[tokio::main]
+    /// async fn main() {
+    ///     let credentials = Credentials::new("username", "password");
+    ///     let client = Api::new_login("url", credentials)
+    ///         .await
+    ///         .unwrap();
+    ///
+    ///     let status = client.search_status(Some(1337))
+    ///         .await
+    ///         .unwrap();
+    ///
+    ///     for search in status {
+    ///         println!("{:?}", search);
+    ///     }
+    /// }
+    /// ```
     pub async fn search_status(&self, id: Option<u64>) -> Result<Vec<Search>, Error> {
         let mut query = vec![];
         if let Some(id) = id {
@@ -103,6 +160,26 @@ impl super::Api {
     /// * `limit` - The maximum number of results to return. A value of `0` indicates no limit.
     /// * `offset` - The starting point for results. If negative, counts backwards (e.g., `-2` retrieves the 2 most recent results).
     ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use qbit::{Api, Credentials};
+    ///
+    /// #[tokio::main]
+    /// async fn main() {
+    ///     let credentials = Credentials::new("username", "password");
+    ///     let client = Api::new_login("url", credentials)
+    ///         .await
+    ///         .unwrap();
+    ///
+    ///     let searchs = client.search_results(1337, 10, None)
+    ///         .await
+    ///         .unwrap();
+    ///
+    ///     println!("{:#?}", searchs);
+    ///
+    /// }
+    /// ```
     pub async fn search_results(
         &self,
         id: u64,
@@ -136,6 +213,23 @@ impl super::Api {
     /// # Arguments
     /// * `id` - The unique identifier of the search job.
     ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use qbit::{Api, Credentials};
+    ///
+    /// #[tokio::main]
+    /// async fn main() {
+    ///     let credentials = Credentials::new("username", "password");
+    ///     let client = Api::new_login("url", credentials)
+    ///         .await
+    ///         .unwrap();
+    ///
+    ///     let result = client.search_delete(1337).await;
+    ///
+    ///     assert!(result.is_ok());
+    /// }
+    /// ```
     pub async fn search_delete(&self, id: u64) -> Result<(), Error> {
         let form = multipart::Form::new().text("id", id.to_string());
 
@@ -153,6 +247,27 @@ impl super::Api {
     ///
     /// [official documentation](https://github.com/qbittorrent/qBittorrent/wiki/WebUI-API-(qBittorrent-5.0)#get-search-plugins)
     ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use qbit::{Api, Credentials};
+    ///
+    /// #[tokio::main]
+    /// async fn main() {
+    ///     let credentials = Credentials::new("username", "password");
+    ///     let client = Api::new_login("url", credentials)
+    ///         .await
+    ///         .unwrap();
+    ///
+    ///     let plugins = client.search_plugins()
+    ///         .await
+    ///         .unwrap();
+    ///
+    ///     for plugin in plugins {
+    ///         println!("{:?}", plugin);
+    ///     }
+    /// }
+    /// ```
     pub async fn search_plugins(&self) -> Result<Vec<SearchPlugin>, Error> {
         let plugins = self
             ._get("search/plugins")
@@ -173,6 +288,23 @@ impl super::Api {
     /// # Arguments
     /// * `sources` - List of Url and file path of the plugin to install.
     ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use qbit::{Api, Credentials};
+    ///
+    /// #[tokio::main]
+    /// async fn main() {
+    ///     let credentials = Credentials::new("username", "password");
+    ///     let client = Api::new_login("url", credentials)
+    ///         .await
+    ///         .unwrap();
+    ///
+    ///     let result = client.search_install_plugin(vec!["plugin"]).await;
+    ///
+    ///     assert!(result.is_ok());
+    /// }
+    /// ```
     pub async fn search_install_plugin(&self, sources: Vec<&str>) -> Result<(), Error> {
         let form = multipart::Form::new().text("sources", sources.join("|"));
 
@@ -193,6 +325,23 @@ impl super::Api {
     /// # Arguments
     /// * `names` - List of names for torrents to uninstall.
     ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use qbit::{Api, Credentials};
+    ///
+    /// #[tokio::main]
+    /// async fn main() {
+    ///     let credentials = Credentials::new("username", "password");
+    ///     let client = Api::new_login("url", credentials)
+    ///         .await
+    ///         .unwrap();
+    ///
+    ///     let result = client.search_uninstall_plugin(vec!["plugin"]).await;
+    ///
+    ///     assert!(result.is_ok());
+    /// }
+    /// ```
     pub async fn search_uninstall_plugin(&self, names: Vec<&str>) -> Result<(), Error> {
         let form = multipart::Form::new().text("names", names.join("|"));
 
@@ -213,6 +362,23 @@ impl super::Api {
     /// # Arguments
     /// * `names` - List of names for torrents to enable.
     ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use qbit::{Api, Credentials};
+    ///
+    /// #[tokio::main]
+    /// async fn main() {
+    ///     let credentials = Credentials::new("username", "password");
+    ///     let client = Api::new_login("url", credentials)
+    ///         .await
+    ///         .unwrap();
+    ///
+    ///     let result = client.search_enable_plugin(vec!["plugin"], true).await;
+    ///
+    ///     assert!(result.is_ok());
+    /// }
+    /// ```
     pub async fn search_enable_plugin(&self, names: Vec<&str>, enable: bool) -> Result<(), Error> {
         let form = multipart::Form::new()
             .text("names", names.join("|"))
@@ -232,6 +398,23 @@ impl super::Api {
     ///
     /// [official documentation](https://github.com/qbittorrent/qBittorrent/wiki/WebUI-API-(qBittorrent-5.0)#update-search-plugins)
     ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use qbit::{Api, Credentials};
+    ///
+    /// #[tokio::main]
+    /// async fn main() {
+    ///     let credentials = Credentials::new("username", "password");
+    ///     let client = Api::new_login("url", credentials)
+    ///         .await
+    ///         .unwrap();
+    ///
+    ///     let result = client.search_update_plugin().await;
+    ///
+    ///     assert!(result.is_ok());
+    /// }
+    /// ```
     pub async fn search_update_plugin(&self) -> Result<(), Error> {
         self._post("search/updatePlugins")
             .await?

--- a/src/client/sync.rs
+++ b/src/client/sync.rs
@@ -15,6 +15,23 @@ impl super::Api {
     ///
     /// * `rid` - Response ID. If not provided, `rid=0` will be assumed.
     ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use qbit::{Api, Credentials};
+    ///
+    /// #[tokio::main]
+    /// async fn main() {
+    ///     let credentials = Credentials::new("username", "password");
+    ///     let client = Api::new_login("url", credentials)
+    ///         .await
+    ///         .unwrap();
+    ///
+    ///     let data = client.main_data(None).await.unwrap();
+    ///
+    ///     println!("{:#?}", data);
+    /// }
+    /// ```
     pub async fn main_data(&self, rid: Option<i64>) -> Result<MainData, Error> {
         let mut query = vec![];
         if let Some(rid) = rid {
@@ -46,6 +63,23 @@ impl super::Api {
     /// * `hash` - Torrent hash.
     /// * `rid` - Response ID. If not provided, `rid=0` will be assumed.
     ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use qbit::{Api, Credentials};
+    ///
+    /// #[tokio::main]
+    /// async fn main() {
+    ///     let credentials = Credentials::new("username", "password");
+    ///     let client = Api::new_login("url", credentials)
+    ///         .await
+    ///         .unwrap();
+    ///
+    ///     let data = client.peers_data("hash", None).await.unwrap();
+    ///
+    ///     println!("{:#?}", data);
+    /// }
+    /// ```
     pub async fn peers_data(&self, hash: &str, rid: Option<i64>) -> Result<PeersData, Error> {
         let mut query = vec![];
         query.push(("hash", hash.to_string()));

--- a/src/client/torrent.rs
+++ b/src/client/torrent.rs
@@ -19,6 +19,27 @@ impl super::Api {
     ///
     /// * `parames` - Parameter object
     ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use qbit::{Api, Credentials};
+    /// use qbit::parameters::TorrentListParams;
+    ///
+    /// #[tokio::main]
+    /// async fn main() {
+    ///     let credentials = Credentials::new("username", "password");
+    ///     let client = Api::new_login("url", credentials)
+    ///         .await
+    ///         .unwrap();
+    ///
+    ///     let param = TorrentListParams::default();
+    ///     let torrents = client.torrents(Some(param)).await.unwrap();
+    ///
+    ///     for torrent in torrents {
+    ///         println!("{:?}", torrent);
+    ///     }
+    /// }
+    /// ```
     pub async fn torrents(&self, params: Option<TorrentListParams>) -> Result<Vec<Torrent>, Error> {
         let mut query = vec![];
 
@@ -68,6 +89,23 @@ impl super::Api {
     ///
     /// * `hash` - The hash of the torrent you want to get the generic properties of.
     ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use qbit::{Api, Credentials};
+    ///
+    /// #[tokio::main]
+    /// async fn main() {
+    ///     let credentials = Credentials::new("username", "password");
+    ///     let client = Api::new_login("url", credentials)
+    ///         .await
+    ///         .unwrap();
+    ///
+    ///     let torrent = client.torrent("hash").await.unwrap();
+    ///
+    ///     println!("{:?}", torrent);
+    /// }
+    /// ```
     pub async fn torrent(&self, hash: &str) -> Result<TorrentProperties, Error> {
         let query = vec![("hash", hash)];
 
@@ -92,6 +130,25 @@ impl super::Api {
     ///
     /// * `hash` - The hash of the torrent you want to get the trackers of.
     ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use qbit::{Api, Credentials};
+    ///
+    /// #[tokio::main]
+    /// async fn main() {
+    ///     let credentials = Credentials::new("username", "password");
+    ///     let client = Api::new_login("url", credentials)
+    ///         .await
+    ///         .unwrap();
+    ///
+    ///     let trackers = client.trackers("hash").await.unwrap();
+    ///
+    ///     for tracker in trackers {
+    ///         println!("{:?}", tracker);
+    ///     }
+    /// }
+    /// ```
     pub async fn trackers(&self, hash: &str) -> Result<Vec<Tracker>, Error> {
         let query = vec![("hash", hash)];
 
@@ -116,6 +173,25 @@ impl super::Api {
     ///
     /// * `hash` - The hash of the torrent you want to get the webseeds of.
     ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use qbit::{Api, Credentials};
+    ///
+    /// #[tokio::main]
+    /// async fn main() {
+    ///     let credentials = Credentials::new("username", "password");
+    ///     let client = Api::new_login("url", credentials)
+    ///         .await
+    ///         .unwrap();
+    ///
+    ///     let webseeds = client.webseeds("hash").await.unwrap();
+    ///
+    ///     for webseed in webseeds {
+    ///         println!("{:?}", webseed);
+    ///     }
+    /// }
+    /// ```
     pub async fn webseeds(&self, hash: &str) -> Result<Vec<WebSeed>, Error> {
         let query = vec![("hash", hash)];
 
@@ -142,6 +218,25 @@ impl super::Api {
     /// * `indexes` - The indexes of the files you want to retrieve. If `None`
     ///   all files will be selected.
     ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use qbit::{Api, Credentials};
+    ///
+    /// #[tokio::main]
+    /// async fn main() {
+    ///     let credentials = Credentials::new("username", "password");
+    ///     let client = Api::new_login("url", credentials)
+    ///         .await
+    ///         .unwrap();
+    ///
+    ///     let files = client.files("hash", None).await.unwrap();
+    ///
+    ///     for file in files {
+    ///         println!("{:?}", file);
+    ///     }
+    /// }
+    /// ```
     pub async fn files(
         &self,
         hash: &str,
@@ -181,6 +276,25 @@ impl super::Api {
     ///
     /// * `hash` - The hash of the torrent you want to get the piece states of.
     ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use qbit::{Api, Credentials};
+    ///
+    /// #[tokio::main]
+    /// async fn main() {
+    ///     let credentials = Credentials::new("username", "password");
+    ///     let client = Api::new_login("url", credentials)
+    ///         .await
+    ///         .unwrap();
+    ///
+    ///     let states = client.pieces_states("hash").await.unwrap();
+    ///
+    ///     for state in states {
+    ///         println!("{:?}", state);
+    ///     }
+    /// }
+    /// ```
     pub async fn pieces_states(&self, hash: &str) -> Result<Vec<PiecesState>, Error> {
         let query = vec![("hash", hash)];
 
@@ -205,6 +319,25 @@ impl super::Api {
     ///
     /// * `hash` - The hash of the torrent you want to get the pieces hashes of.
     ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use qbit::{Api, Credentials};
+    ///
+    /// #[tokio::main]
+    /// async fn main() {
+    ///     let credentials = Credentials::new("username", "password");
+    ///     let client = Api::new_login("url", credentials)
+    ///         .await
+    ///         .unwrap();
+    ///
+    ///     let hashes = client.pieces_hashes("hash").await.unwrap();
+    ///
+    ///     for hash in hashes {
+    ///         println!("{}", hash);
+    ///     }
+    /// }
+    /// ```
     pub async fn pieces_hashes(&self, hash: &str) -> Result<Vec<String>, Error> {
         let query = vec![("hash", hash)];
 
@@ -229,6 +362,23 @@ impl super::Api {
     ///
     /// * `hashes` - Hashes list of torrents to stop.
     ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use qbit::{Api, Credentials};
+    ///
+    /// #[tokio::main]
+    /// async fn main() {
+    ///     let credentials = Credentials::new("username", "password");
+    ///     let client = Api::new_login("url", credentials)
+    ///         .await
+    ///         .unwrap();
+    ///
+    ///     let result = client.stop(vec!["Hash1", "Hash2"]).await;
+    ///
+    ///     assert!(result.is_ok());
+    /// }
+    /// ```
     pub async fn stop(&self, hashes: Vec<&str>) -> Result<(), Error> {
         let form = multipart::Form::new().text("hashes", hashes.join("|"));
 
@@ -250,6 +400,23 @@ impl super::Api {
     ///
     /// * `hashes` - Hashes list of torrents to start.
     ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use qbit::{Api, Credentials};
+    ///
+    /// #[tokio::main]
+    /// async fn main() {
+    ///     let credentials = Credentials::new("username", "password");
+    ///     let client = Api::new_login("url", credentials)
+    ///         .await
+    ///         .unwrap();
+    ///
+    ///     let result = client.start(vec!["Hash1", "Hash2"]).await;
+    ///
+    ///     assert!(result.is_ok());
+    /// }
+    /// ```
     pub async fn start(&self, hashes: Vec<&str>) -> Result<(), Error> {
         let form = multipart::Form::new().text("hashes", hashes.join("|"));
 
@@ -273,6 +440,23 @@ impl super::Api {
     /// * `delete_files` - If set to `true`, the downloaded data will also be deleted,
     ///   otherwise has no effect.
     ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use qbit::{Api, Credentials};
+    ///
+    /// #[tokio::main]
+    /// async fn main() {
+    ///     let credentials = Credentials::new("username", "password");
+    ///     let client = Api::new_login("url", credentials)
+    ///         .await
+    ///         .unwrap();
+    ///
+    ///     let result = client.delete(vec!["Hash1", "Hash2"], false).await;
+    ///
+    ///     assert!(result.is_ok());
+    /// }
+    /// ```
     pub async fn delete(&self, hashes: Vec<&str>, delete_files: bool) -> Result<(), Error> {
         let form = multipart::Form::new()
             .text("hashes", hashes.join("|"))
@@ -296,6 +480,23 @@ impl super::Api {
     ///
     /// * `hashes` - Hashes list of torrents to recheck.
     ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use qbit::{Api, Credentials};
+    ///
+    /// #[tokio::main]
+    /// async fn main() {
+    ///     let credentials = Credentials::new("username", "password");
+    ///     let client = Api::new_login("url", credentials)
+    ///         .await
+    ///         .unwrap();
+    ///
+    ///     let result = client.recheck(vec!["Hash1", "Hash2"]).await;
+    ///
+    ///     assert!(result.is_ok());
+    /// }
+    /// ```
     pub async fn recheck(&self, hashes: Vec<&str>) -> Result<(), Error> {
         let form = multipart::Form::new().text("hashes", hashes.join("|"));
 
@@ -317,6 +518,23 @@ impl super::Api {
     ///
     /// * `hashes` - Hashes list of torrents to reannounce.
     ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use qbit::{Api, Credentials};
+    ///
+    /// #[tokio::main]
+    /// async fn main() {
+    ///     let credentials = Credentials::new("username", "password");
+    ///     let client = Api::new_login("url", credentials)
+    ///         .await
+    ///         .unwrap();
+    ///
+    ///     let result = client.reannounce(vec!["Hash1", "Hash2"]).await;
+    ///
+    ///     assert!(result.is_ok());
+    /// }
+    /// ```
     pub async fn reannounce(&self, hashes: Vec<&str>) -> Result<(), Error> {
         let form = multipart::Form::new().text("hashes", hashes.join("|"));
 
@@ -338,6 +556,25 @@ impl super::Api {
     ///
     /// * `params` - Torrent parameters
     ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use qbit::{Api, Credentials};
+    /// use qbit::parameters::AddTorrent;
+    ///
+    /// #[tokio::main]
+    /// async fn main() {
+    ///     let credentials = Credentials::new("username", "password");
+    ///     let client = Api::new_login("url", credentials)
+    ///         .await
+    ///         .unwrap();
+    ///
+    ///     let params = AddTorrent::default();
+    ///     let result = client.add_torrent(params).await;
+    ///
+    ///     assert!(result.is_ok());
+    /// }
+    /// ```
     pub async fn add_torrent(&self, params: AddTorrent) -> Result<(), Error> {
         if params.torrents.is_empty() {
             return Err(Error::InvalidRequest(
@@ -421,6 +658,24 @@ impl super::Api {
     /// * `hash` - Torrent hash.
     /// * `urls` - Trackers urls to add.
     ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use qbit::{Api, Credentials};
+    ///
+    /// #[tokio::main]
+    /// async fn main() {
+    ///     let credentials = Credentials::new("username", "password");
+    ///     let client = Api::new_login("url", credentials)
+    ///         .await
+    ///         .unwrap();
+    ///
+    ///     let urls = vec!["url1", "url2"];
+    ///     let result = client.add_trackers_to_torrent("hash", urls).await;
+    ///
+    ///     assert!(result.is_ok());
+    /// }
+    /// ```
     pub async fn add_trackers_to_torrent(&self, hash: &str, urls: Vec<&str>) -> Result<(), Error> {
         let form = multipart::Form::new()
             .text("hash", hash.to_string())
@@ -446,6 +701,24 @@ impl super::Api {
     /// * `orig_url` - The tracker URL you want to edit.
     /// * `new_url` - The new URL to replace the `orig_url`.
     ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use qbit::{Api, Credentials};
+    ///
+    /// #[tokio::main]
+    /// async fn main() {
+    ///     let credentials = Credentials::new("username", "password");
+    ///     let client = Api::new_login("url", credentials)
+    ///         .await
+    ///         .unwrap();
+    ///
+    ///     let result = client.edit_tracker_for_torrent("hash", "old_url", "new_url")
+    ///         .await;
+    ///
+    ///     assert!(result.is_ok());
+    /// }
+    /// ```
     pub async fn edit_tracker_for_torrent(
         &self,
         hash: &str,
@@ -476,6 +749,24 @@ impl super::Api {
     /// * `hash` - Torrent hash.
     /// * `urls` - Trackers urls to remove.
     ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use qbit::{Api, Credentials};
+    ///
+    /// #[tokio::main]
+    /// async fn main() {
+    ///     let credentials = Credentials::new("username", "password");
+    ///     let client = Api::new_login("url", credentials)
+    ///         .await
+    ///         .unwrap();
+    ///
+    ///     let urls = vec!["url1", "url2"];
+    ///     let result = client.remove_trackers_from_torrent("hash", urls).await;
+    ///
+    ///     assert!(result.is_ok());
+    /// }
+    /// ```
     pub async fn remove_trackers_from_torrent(
         &self,
         hash: &str,
@@ -504,6 +795,25 @@ impl super::Api {
     /// * `hashes` - Torrent hash.
     /// * `peers` - The peer to add. Each peer is a colon-separated `host:port`.
     ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use qbit::{Api, Credentials};
+    ///
+    /// #[tokio::main]
+    /// async fn main() {
+    ///     let credentials = Credentials::new("username", "password");
+    ///     let client = Api::new_login("url", credentials)
+    ///         .await
+    ///         .unwrap();
+    ///
+    ///     let hashes = vec!["hash1", "hash2"];
+    ///     let peers = vec!["alice", "bob"];
+    ///     let result = client.add_peers(hashes, peers).await;
+    ///
+    ///     assert!(result.is_ok());
+    /// }
+    /// ```
     pub async fn add_peers(&self, hashes: Vec<&str>, peers: Vec<&str>) -> Result<(), Error> {
         let form = multipart::Form::new()
             .text("hashes", hashes.join("|"))
@@ -528,6 +838,23 @@ impl super::Api {
     /// * `hashes` - The hashes of the torrents you want to increase the priority of.
     ///   If `None` all torrents are selected.
     ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use qbit::{Api, Credentials};
+    ///
+    /// #[tokio::main]
+    /// async fn main() {
+    ///     let credentials = Credentials::new("username", "password");
+    ///     let client = Api::new_login("url", credentials)
+    ///         .await
+    ///         .unwrap();
+    ///
+    ///     let result = client.increase_priority(None).await;
+    ///
+    ///     assert!(result.is_ok());
+    /// }
+    /// ```
     pub async fn increase_priority(&self, hashes: Option<Vec<&str>>) -> Result<(), Error> {
         let form = multipart::Form::new().text("hashes", hashes.unwrap_or(vec!["all"]).join("|"));
 
@@ -550,6 +877,23 @@ impl super::Api {
     /// * `hashes` - The hashes of the torrents you want to decrease the priority of.
     ///   If `None` all torrents are selected.
     ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use qbit::{Api, Credentials};
+    ///
+    /// #[tokio::main]
+    /// async fn main() {
+    ///     let credentials = Credentials::new("username", "password");
+    ///     let client = Api::new_login("url", credentials)
+    ///         .await
+    ///         .unwrap();
+    ///
+    ///     let result = client.decrease_priority(None).await;
+    ///
+    ///     assert!(result.is_ok());
+    /// }
+    /// ```
     pub async fn decrease_priority(&self, hashes: Option<Vec<&str>>) -> Result<(), Error> {
         let form = multipart::Form::new().text("hashes", hashes.unwrap_or(vec!["all"]).join("|"));
 
@@ -572,6 +916,23 @@ impl super::Api {
     /// * `hashes` - The hashes of the torrents you want to max the priority of.
     ///   If `None` all torrents are selected.
     ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use qbit::{Api, Credentials};
+    ///
+    /// #[tokio::main]
+    /// async fn main() {
+    ///     let credentials = Credentials::new("username", "password");
+    ///     let client = Api::new_login("url", credentials)
+    ///         .await
+    ///         .unwrap();
+    ///
+    ///     let result = client.max_priority(None).await;
+    ///
+    ///     assert!(result.is_ok());
+    /// }
+    /// ```
     pub async fn max_priority(&self, hashes: Option<Vec<&str>>) -> Result<(), Error> {
         let form = multipart::Form::new().text("hashes", hashes.unwrap_or(vec!["all"]).join("|"));
 
@@ -594,6 +955,23 @@ impl super::Api {
     /// * `hashes` - The hashes of the torrents you want to min the priority of.
     ///   If `None` all torrents are selected.
     ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use qbit::{Api, Credentials};
+    ///
+    /// #[tokio::main]
+    /// async fn main() {
+    ///     let credentials = Credentials::new("username", "password");
+    ///     let client = Api::new_login("url", credentials)
+    ///         .await
+    ///         .unwrap();
+    ///
+    ///     let result = client.min_priority(None).await;
+    ///
+    ///     assert!(result.is_ok());
+    /// }
+    /// ```
     pub async fn min_priority(&self, hashes: Option<Vec<&str>>) -> Result<(), Error> {
         let form = multipart::Form::new().text("hashes", hashes.unwrap_or(vec!["all"]).join("|"));
 
@@ -617,6 +995,24 @@ impl super::Api {
     /// * `file_ids` - File ids.
     /// * `priority` - File priority to set.
     ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use qbit::{Api, Credentials};
+    /// use qbit::models::FilePriority;
+    ///
+    /// #[tokio::main]
+    /// async fn main() {
+    ///     let credentials = Credentials::new("username", "password");
+    ///     let client = Api::new_login("url", credentials)
+    ///         .await
+    ///         .unwrap();
+    ///
+    ///     let result = client.set_file_priority("hash", vec![0,1,2], FilePriority::High).await;
+    ///
+    ///     assert!(result.is_ok());
+    /// }
+    /// ```
     pub async fn set_file_priority(
         &self,
         hash: &str,
@@ -654,6 +1050,25 @@ impl super::Api {
     /// * `hashes` - The hashes of the torrents you want to get the download limit of.
     ///   If `None` all torrents are selected.
     ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use qbit::{Api, Credentials};
+    ///
+    /// #[tokio::main]
+    /// async fn main() {
+    ///     let credentials = Credentials::new("username", "password");
+    ///     let client = Api::new_login("url", credentials)
+    ///         .await
+    ///         .unwrap();
+    ///
+    ///     let limits = client.download_limit(None).await.unwrap();
+    ///
+    ///     for limit in limits {
+    ///         println!("{:?}", limit);
+    ///     }
+    /// }
+    /// ```
     pub async fn download_limit(
         &self,
         hashes: Option<Vec<&str>>,
@@ -683,6 +1098,23 @@ impl super::Api {
     ///   If `None` all torrents are selected.
     /// * `limit` - Download limit
     ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use qbit::{Api, Credentials};
+    ///
+    /// #[tokio::main]
+    /// async fn main() {
+    ///     let credentials = Credentials::new("username", "password");
+    ///     let client = Api::new_login("url", credentials)
+    ///         .await
+    ///         .unwrap();
+    ///
+    ///     let result = client.set_download_limit(None, 10).await;
+    ///
+    ///     assert!(result.is_ok());
+    /// }
+    /// ```
     pub async fn set_download_limit(
         &self,
         hashes: Option<Vec<&str>>,
@@ -718,6 +1150,23 @@ impl super::Api {
     ///   torrent is allowed to seed while being inactive. `-2` means the global limit
     ///   should be used, `-1` means no limit.
     ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use qbit::{Api, Credentials};
+    ///
+    /// #[tokio::main]
+    /// async fn main() {
+    ///     let credentials = Credentials::new("username", "password");
+    ///     let client = Api::new_login("url", credentials)
+    ///         .await
+    ///         .unwrap();
+    ///
+    ///     let result = client.set_share_limit(None, 0.3, 100, 100).await;
+    ///
+    ///     assert!(result.is_ok());
+    /// }
+    /// ```
     pub async fn set_share_limit(
         &self,
         hashes: Option<Vec<&str>>,
@@ -753,6 +1202,25 @@ impl super::Api {
     /// * `hashes` - The hashes of the torrents you want the upload limit of.
     ///   If `None` all torrents are selected.
     ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use qbit::{Api, Credentials};
+    ///
+    /// #[tokio::main]
+    /// async fn main() {
+    ///     let credentials = Credentials::new("username", "password");
+    ///     let client = Api::new_login("url", credentials)
+    ///         .await
+    ///         .unwrap();
+    ///
+    ///     let limits = client.upload_limit(None).await.unwrap();
+    ///
+    ///     for limit in limits {
+    ///         println!("{:?}", limit);
+    ///     }
+    /// }
+    /// ```
     pub async fn upload_limit(
         &self,
         hashes: Option<Vec<&str>>,
@@ -782,6 +1250,23 @@ impl super::Api {
     ///   If `None` all torrents are selected.
     /// * `limit` - Upload limit
     ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use qbit::{Api, Credentials};
+    ///
+    /// #[tokio::main]
+    /// async fn main() {
+    ///     let credentials = Credentials::new("username", "password");
+    ///     let client = Api::new_login("url", credentials)
+    ///         .await
+    ///         .unwrap();
+    ///
+    ///     let result = client.set_upload_limit(None, 10).await;
+    ///
+    ///     assert!(result.is_ok());
+    /// }
+    /// ```
     pub async fn set_upload_limit(
         &self,
         hashes: Option<Vec<&str>>,
@@ -811,6 +1296,23 @@ impl super::Api {
     ///   If `None` all torrents are selected.
     /// * `location` - Location to download the torrent to.
     ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use qbit::{Api, Credentials};
+    ///
+    /// #[tokio::main]
+    /// async fn main() {
+    ///     let credentials = Credentials::new("username", "password");
+    ///     let client = Api::new_login("url", credentials)
+    ///         .await
+    ///         .unwrap();
+    ///
+    ///     let result = client.set_location(None, "new/location").await;
+    ///
+    ///     assert!(result.is_ok());
+    /// }
+    /// ```
     pub async fn set_location(
         &self,
         hashes: Option<Vec<&str>>,
@@ -839,6 +1341,23 @@ impl super::Api {
     /// * `hash` - The hash of the torrent you want to set the name of.
     /// * `name` - Location to download the torrent to.
     ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use qbit::{Api, Credentials};
+    ///
+    /// #[tokio::main]
+    /// async fn main() {
+    ///     let credentials = Credentials::new("username", "password");
+    ///     let client = Api::new_login("url", credentials)
+    ///         .await
+    ///         .unwrap();
+    ///
+    ///     let result = client.set_name("hash", "new_torrent_name").await;
+    ///
+    ///     assert!(result.is_ok());
+    /// }
+    /// ```
     pub async fn set_name(&self, hash: &str, name: &str) -> Result<(), Error> {
         let form = multipart::Form::new()
             .text("hash", hash.to_string())
@@ -864,6 +1383,23 @@ impl super::Api {
     ///   If `None` all torrents are selected.
     /// * `category` - Name of the category you want to set.
     ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use qbit::{Api, Credentials};
+    ///
+    /// #[tokio::main]
+    /// async fn main() {
+    ///     let credentials = Credentials::new("username", "password");
+    ///     let client = Api::new_login("url", credentials)
+    ///         .await
+    ///         .unwrap();
+    ///
+    ///     let result = client.set_category(None, "category").await;
+    ///
+    ///     assert!(result.is_ok());
+    /// }
+    /// ```
     pub async fn set_category(
         &self,
         hashes: Option<Vec<&str>>,
@@ -887,6 +1423,25 @@ impl super::Api {
     ///
     /// [official documentation](https://github.com/qbittorrent/qBittorrent/wiki/WebUI-API-(qBittorrent-5.0)#get-all-categories)
     ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use qbit::{Api, Credentials};
+    ///
+    /// #[tokio::main]
+    /// async fn main() {
+    ///     let credentials = Credentials::new("username", "password");
+    ///     let client = Api::new_login("url", credentials)
+    ///         .await
+    ///         .unwrap();
+    ///
+    ///     let categories = client.categories().await.unwrap();
+    ///
+    ///     for categori in categories {
+    ///         println!("{}", categori);
+    ///     }
+    /// }
+    /// ```
     pub async fn categories(&self) -> Result<Vec<String>, Error> {
         let categories = self
             ._get("torrents/categories")
@@ -909,6 +1464,23 @@ impl super::Api {
     /// * `category` - Name for the category to create.
     /// * `save_path` - Path to download torrents for the category.
     ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use qbit::{Api, Credentials};
+    ///
+    /// #[tokio::main]
+    /// async fn main() {
+    ///     let credentials = Credentials::new("username", "password");
+    ///     let client = Api::new_login("url", credentials)
+    ///         .await
+    ///         .unwrap();
+    ///
+    ///     let result = client.create_category("category", "save/path").await;
+    ///
+    ///     assert!(result.is_ok());
+    /// }
+    /// ```
     pub async fn create_category(&self, category: &str, save_path: &str) -> Result<(), Error> {
         let form = multipart::Form::new()
             .text("category", category.to_string())
@@ -933,6 +1505,23 @@ impl super::Api {
     /// * `category` - Name for the category to edit.
     /// * `save_path` - Path to download torrents for the category.
     ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use qbit::{Api, Credentials};
+    ///
+    /// #[tokio::main]
+    /// async fn main() {
+    ///     let credentials = Credentials::new("username", "password");
+    ///     let client = Api::new_login("url", credentials)
+    ///         .await
+    ///         .unwrap();
+    ///
+    ///     let result = client.edit_category("category", "new/save/path").await;
+    ///
+    ///     assert!(result.is_ok());
+    /// }
+    /// ```
     pub async fn edit_category(&self, category: &str, save_path: &str) -> Result<(), Error> {
         let form = multipart::Form::new()
             .text("category", category.to_string())
@@ -956,6 +1545,24 @@ impl super::Api {
     ///
     /// * `categories` - List of category names to remove.
     ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use qbit::{Api, Credentials};
+    ///
+    /// #[tokio::main]
+    /// async fn main() {
+    ///     let credentials = Credentials::new("username", "password");
+    ///     let client = Api::new_login("url", credentials)
+    ///         .await
+    ///         .unwrap();
+    ///
+    ///     let categories = vec!["movie", "distro"];
+    ///     let result = client.remove_categories(categories).await;
+    ///
+    ///     assert!(result.is_ok());
+    /// }
+    /// ```
     pub async fn remove_categories(&self, categories: Vec<&str>) -> Result<(), Error> {
         let form = multipart::Form::new().text("categories", categories.join("\n"));
 
@@ -979,6 +1586,24 @@ impl super::Api {
     ///   If `None` all torrents are selected.
     /// * `tags` - List of names for the tags you want to set.
     ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use qbit::{Api, Credentials};
+    ///
+    /// #[tokio::main]
+    /// async fn main() {
+    ///     let credentials = Credentials::new("username", "password");
+    ///     let client = Api::new_login("url", credentials)
+    ///         .await
+    ///         .unwrap();
+    ///
+    ///     let tags = vec!["listed"];
+    ///     let result = client.add_tags(None, tags).await;
+    ///
+    ///     assert!(result.is_ok());
+    /// }
+    /// ```
     pub async fn add_tags(&self, hashes: Option<Vec<&str>>, tags: Vec<&str>) -> Result<(), Error> {
         let form = multipart::Form::new()
             .text("hashes", hashes.unwrap_or(vec!["all"]).join("|"))
@@ -1004,6 +1629,24 @@ impl super::Api {
     ///   If `None` all torrents are selected.
     /// * `tags` - List of names for the tags you want to remove.
     ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use qbit::{Api, Credentials};
+    ///
+    /// #[tokio::main]
+    /// async fn main() {
+    ///     let credentials = Credentials::new("username", "password");
+    ///     let client = Api::new_login("url", credentials)
+    ///         .await
+    ///         .unwrap();
+    ///
+    ///     let tags = vec!["listed"];
+    ///     let result = client.remove_tags(None, tags).await;
+    ///
+    ///     assert!(result.is_ok());
+    /// }
+    /// ```
     pub async fn remove_tags(
         &self,
         hashes: Option<Vec<&str>>,
@@ -1027,6 +1670,25 @@ impl super::Api {
     ///
     /// [official documentation](https://github.com/qbittorrent/qBittorrent/wiki/WebUI-API-(qBittorrent-5.0)#get-all-tags)
     ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use qbit::{Api, Credentials};
+    ///
+    /// #[tokio::main]
+    /// async fn main() {
+    ///     let credentials = Credentials::new("username", "password");
+    ///     let client = Api::new_login("url", credentials)
+    ///         .await
+    ///         .unwrap();
+    ///
+    ///     let tags = client.tags().await.unwrap();
+    ///
+    ///     for tag in tags {
+    ///         println!("{}", tag);
+    ///     }
+    /// }
+    /// ```
     pub async fn tags(&self) -> Result<Vec<String>, Error> {
         let tags = self
             ._get("torrents/tags")
@@ -1048,6 +1710,24 @@ impl super::Api {
     ///
     /// * `tags` - List of tags to create.
     ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use qbit::{Api, Credentials};
+    ///
+    /// #[tokio::main]
+    /// async fn main() {
+    ///     let credentials = Credentials::new("username", "password");
+    ///     let client = Api::new_login("url", credentials)
+    ///         .await
+    ///         .unwrap();
+    ///
+    ///     let tags = vec!["listed"];
+    ///     let result = client.create_tags(tags).await;
+    ///
+    ///     assert!(result.is_ok());
+    /// }
+    /// ```
     pub async fn create_tags(&self, tags: Vec<&str>) -> Result<(), Error> {
         let form = multipart::Form::new().text("tags", tags.join(","));
 
@@ -1069,6 +1749,24 @@ impl super::Api {
     ///
     /// * `tags` - List of tags to delete.
     ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use qbit::{Api, Credentials};
+    ///
+    /// #[tokio::main]
+    /// async fn main() {
+    ///     let credentials = Credentials::new("username", "password");
+    ///     let client = Api::new_login("url", credentials)
+    ///         .await
+    ///         .unwrap();
+    ///
+    ///     let tags = vec!["listed"];
+    ///     let result = client.delete_tags(tags).await;
+    ///
+    ///     assert!(result.is_ok());
+    /// }
+    /// ```
     pub async fn delete_tags(&self, tags: Vec<&str>) -> Result<(), Error> {
         let form = multipart::Form::new().text("tags", tags.join(","));
 
@@ -1092,6 +1790,23 @@ impl super::Api {
     ///   If `None` all torrents are selected.
     /// * `enable`
     ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use qbit::{Api, Credentials};
+    ///
+    /// #[tokio::main]
+    /// async fn main() {
+    ///     let credentials = Credentials::new("username", "password");
+    ///     let client = Api::new_login("url", credentials)
+    ///         .await
+    ///         .unwrap();
+    ///
+    ///     let result = client.set_automatic_torrent_management(None, true).await;
+    ///
+    ///     assert!(result.is_ok());
+    /// }
+    /// ```
     pub async fn set_automatic_torrent_management(
         &self,
         hashes: Option<Vec<&str>>,
@@ -1120,6 +1835,23 @@ impl super::Api {
     /// * `hashes` - The hashes of the torrents you want to toggle sequential download for.
     ///   If `None` all torrents are selected.
     ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use qbit::{Api, Credentials};
+    ///
+    /// #[tokio::main]
+    /// async fn main() {
+    ///     let credentials = Credentials::new("username", "password");
+    ///     let client = Api::new_login("url", credentials)
+    ///         .await
+    ///         .unwrap();
+    ///
+    ///     let result = client.toggle_sequential_download(None).await;
+    ///
+    ///     assert!(result.is_ok());
+    /// }
+    /// ```
     pub async fn toggle_sequential_download(&self, hashes: Option<Vec<&str>>) -> Result<(), Error> {
         let form = multipart::Form::new().text("hashes", hashes.unwrap_or(vec!["all"]).join("|"));
 
@@ -1142,6 +1874,23 @@ impl super::Api {
     /// * `hashes` - The hashes of the torrents you want to toggle first/last piece priority for.
     ///   If `None` all torrents are selected.
     ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use qbit::{Api, Credentials};
+    ///
+    /// #[tokio::main]
+    /// async fn main() {
+    ///     let credentials = Credentials::new("username", "password");
+    ///     let client = Api::new_login("url", credentials)
+    ///         .await
+    ///         .unwrap();
+    ///
+    ///     let result = client.toggle_first_last_priority(None).await;
+    ///
+    ///     assert!(result.is_ok());
+    /// }
+    /// ```
     pub async fn toggle_first_last_priority(&self, hashes: Option<Vec<&str>>) -> Result<(), Error> {
         let form = multipart::Form::new().text("hashes", hashes.unwrap_or(vec!["all"]).join("|"));
 
@@ -1165,6 +1914,23 @@ impl super::Api {
     ///   If `None` all torrents are selected.
     /// * `enable`
     ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use qbit::{Api, Credentials};
+    ///
+    /// #[tokio::main]
+    /// async fn main() {
+    ///     let credentials = Credentials::new("username", "password");
+    ///     let client = Api::new_login("url", credentials)
+    ///         .await
+    ///         .unwrap();
+    ///
+    ///     let result = client.set_force_start(None, false).await;
+    ///
+    ///     assert!(result.is_ok());
+    /// }
+    /// ```
     pub async fn set_force_start(
         &self,
         hashes: Option<Vec<&str>>,
@@ -1194,6 +1960,23 @@ impl super::Api {
     ///   If `None` all torrents are selected.
     /// * `enable`
     ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use qbit::{Api, Credentials};
+    ///
+    /// #[tokio::main]
+    /// async fn main() {
+    ///     let credentials = Credentials::new("username", "password");
+    ///     let client = Api::new_login("url", credentials)
+    ///         .await
+    ///         .unwrap();
+    ///
+    ///     let result = client.set_super_seeding(None, false).await;
+    ///
+    ///     assert!(result.is_ok());
+    /// }
+    /// ```
     pub async fn set_super_seeding(
         &self,
         hashes: Option<Vec<&str>>,
@@ -1223,6 +2006,23 @@ impl super::Api {
     /// * `oldPath` - The old path of the torrent
     /// * `newPath` - The new path to use for the file
     ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use qbit::{Api, Credentials};
+    ///
+    /// #[tokio::main]
+    /// async fn main() {
+    ///     let credentials = Credentials::new("username", "password");
+    ///     let client = Api::new_login("url", credentials)
+    ///         .await
+    ///         .unwrap();
+    ///
+    ///     let result = client.rename_file("hash", "old/file", "new/file").await;
+    ///
+    ///     assert!(result.is_ok());
+    /// }
+    /// ```
     pub async fn rename_file(
         &self,
         hash: &str,
@@ -1254,6 +2054,23 @@ impl super::Api {
     /// * `oldPath` - The old path of the torrent
     /// * `newPath` - The new path to use for the file
     ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use qbit::{Api, Credentials};
+    ///
+    /// #[tokio::main]
+    /// async fn main() {
+    ///     let credentials = Credentials::new("username", "password");
+    ///     let client = Api::new_login("url", credentials)
+    ///         .await
+    ///         .unwrap();
+    ///
+    ///     let result = client.rename_folder("hash", "old/folder", "new/folder").await;
+    ///
+    ///     assert!(result.is_ok());
+    /// }
+    /// ```
     pub async fn rename_folder(
         &self,
         hash: &str,

--- a/src/client/torrent.rs
+++ b/src/client/torrent.rs
@@ -1254,7 +1254,7 @@ impl super::Api {
     /// * `oldPath` - The old path of the torrent
     /// * `newPath` - The new path to use for the file
     ///
-    pub async fn torrent_rename_folder(
+    pub async fn rename_folder(
         &self,
         hash: &str,
         old_path: &str,

--- a/src/client/torrent.rs
+++ b/src/client/torrent.rs
@@ -1069,7 +1069,7 @@ impl super::Api {
     ///
     /// * `tags` - List of tags to delete.
     ///
-    pub async fn torrent_delete_tags(&self, tags: Vec<&str>) -> Result<(), Error> {
+    pub async fn delete_tags(&self, tags: Vec<&str>) -> Result<(), Error> {
         let form = multipart::Form::new().text("tags", tags.join(","));
 
         self._post("torrents/deleteTags")

--- a/src/client/transfer.rs
+++ b/src/client/transfer.rs
@@ -9,6 +9,23 @@ impl super::Api {
     ///
     /// [official documentation](https://github.com/qbittorrent/qBittorrent/wiki/WebUI-API-(qBittorrent-5.0)#get-global-transfer-info)
     ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use qbit::{Api, Credentials};
+    ///
+    /// #[tokio::main]
+    /// async fn main() {
+    ///     let credentials = Credentials::new("username", "password");
+    ///     let client = Api::new_login("url", credentials)
+    ///         .await
+    ///         .unwrap();
+    ///
+    ///     let info = client.global_transfer_info().await.unwrap();
+    ///
+    ///     println!("{:?}", info);
+    /// }
+    /// ```
     pub async fn global_transfer_info(&self) -> Result<TransferInfo, Error> {
         let info = self
             ._get("transfer/info")
@@ -27,6 +44,24 @@ impl super::Api {
     /// The response is 1 if alternative speed limits are enabled, 0 otherwise.
     ///
     /// [official documentation](https://github.com/qbittorrent/qBittorrent/wiki/WebUI-API-(qBittorrent-5.0)#get-alternative-speed-limits-state)
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use qbit::{Api, Credentials};
+    ///
+    /// #[tokio::main]
+    /// async fn main() {
+    ///     let credentials = Credentials::new("username", "password");
+    ///     let client = Api::new_login("url", credentials)
+    ///         .await
+    ///         .unwrap();
+    ///
+    ///     let state = client.alternative_speed_limit().await.unwrap();
+    ///
+    ///     println!("Alternative: {}", state);
+    /// }
+    /// ```
     pub async fn alternative_speed_limit(&self) -> Result<bool, Error> {
         let is_active = self
             ._get("transfer/speedLimitsMode")
@@ -44,6 +79,23 @@ impl super::Api {
     ///
     /// [official documentation](https://github.com/qbittorrent/qBittorrent/wiki/WebUI-API-(qBittorrent-5.0)#toggle-alternative-speed-limits)
     ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use qbit::{Api, Credentials};
+    ///
+    /// #[tokio::main]
+    /// async fn main() {
+    ///     let credentials = Credentials::new("username", "password");
+    ///     let client = Api::new_login("url", credentials)
+    ///         .await
+    ///         .unwrap();
+    ///
+    ///     let result = client.toggle_alternative_speed_limit().await;
+    ///
+    ///     assert!(result.is_ok());
+    /// }
+    /// ```
     pub async fn toggle_alternative_speed_limit(&self) -> Result<(), Error> {
         self._post("transfer/toggleSpeedLimitsMode")
             .await?
@@ -58,6 +110,23 @@ impl super::Api {
     ///
     /// [official documentation](https://github.com/qbittorrent/qBittorrent/wiki/WebUI-API-(qBittorrent-5.0)#get-global-download-limit)
     ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use qbit::{Api, Credentials};
+    ///
+    /// #[tokio::main]
+    /// async fn main() {
+    ///     let credentials = Credentials::new("username", "password");
+    ///     let client = Api::new_login("url", credentials)
+    ///         .await
+    ///         .unwrap();
+    ///
+    ///     let limit = client.global_download_limit().await.unwrap();
+    ///
+    ///     println!("Download limit: {}", limit);
+    /// }
+    /// ```
     pub async fn global_download_limit(&self) -> Result<u64, Error> {
         let limites = self
             ._get("transfer/downloadLimit")
@@ -79,6 +148,23 @@ impl super::Api {
     ///
     /// * `limit` - The global download speed limit to set in bytes/second. `0` if no limit.
     ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use qbit::{Api, Credentials};
+    ///
+    /// #[tokio::main]
+    /// async fn main() {
+    ///     let credentials = Credentials::new("username", "password");
+    ///     let client = Api::new_login("url", credentials)
+    ///         .await
+    ///         .unwrap();
+    ///
+    ///     let result = client.set_global_download_limit(1337).await;
+    ///
+    ///     assert!(result.is_ok());
+    /// }
+    /// ```
     pub async fn set_global_download_limit(&self, limit: u64) -> Result<(), Error> {
         let form = multipart::Form::new().text("limit", limit.to_string());
 
@@ -96,6 +182,23 @@ impl super::Api {
     ///
     /// [official documentation](https://github.com/qbittorrent/qBittorrent/wiki/WebUI-API-(qBittorrent-5.0)#get-global-upload-limit)
     ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use qbit::{Api, Credentials};
+    ///
+    /// #[tokio::main]
+    /// async fn main() {
+    ///     let credentials = Credentials::new("username", "password");
+    ///     let client = Api::new_login("url", credentials)
+    ///         .await
+    ///         .unwrap();
+    ///
+    ///     let limit = client.global_upload_limit().await.unwrap();
+    ///
+    ///     println!("Upload limit: {}", limit);
+    /// }
+    /// ```
     pub async fn global_upload_limit(&self) -> Result<u64, Error> {
         let limites = self
             ._get("transfer/uploadLimit")
@@ -117,6 +220,23 @@ impl super::Api {
     ///
     /// * `limit` - The global upload speed limit to set in bytes/second. `0` if no limit.
     ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use qbit::{Api, Credentials};
+    ///
+    /// #[tokio::main]
+    /// async fn main() {
+    ///     let credentials = Credentials::new("username", "password");
+    ///     let client = Api::new_login("url", credentials)
+    ///         .await
+    ///         .unwrap();
+    ///
+    ///     let result = client.set_global_upload_limit(1337).await;
+    ///
+    ///     assert!(result.is_ok());
+    /// }
+    /// ```
     pub async fn set_global_upload_limit(&self, limit: u64) -> Result<(), Error> {
         let form = multipart::Form::new().text("limit", limit.to_string());
 
@@ -138,6 +258,24 @@ impl super::Api {
     ///
     /// * `peers` - The peer to ban, or multiple peers. Each peer is a colon-separated `host:port`
     ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use qbit::{Api, Credentials};
+    ///
+    /// #[tokio::main]
+    /// async fn main() {
+    ///     let credentials = Credentials::new("username", "password");
+    ///     let client = Api::new_login("url", credentials)
+    ///         .await
+    ///         .unwrap();
+    ///
+    ///     let peers = vec!["alice".to_string(), "bob".to_string()];
+    ///     let result = client.peers_ban(peers).await;
+    ///
+    ///     assert!(result.is_ok());
+    /// }
+    /// ```
     pub async fn peers_ban(&self, peers: Vec<String>) -> Result<(), Error> {
         let form = multipart::Form::new().text("peers", peers.join("|"));
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,32 @@
+//! # Qbittorrent Web API wrapper
+//!
+//! This module provides a wrapper around the Qbit Web API, enabling
+//! interaction with the API through a structured and type-safe interface.
+//!
+//! The wrapper includes functionality for managing authentication states,
+//! handling credentials, and interacting with various API endpoints.
+//!
+//! The library is designed to support Qbittorrent version `5.1`
+//!
+//! # Example
+//!
+//! Basic usage to get all torrents
+//! ```rust
+//! use qbit::{Api, Credentials};
+//!
+//! let credentials = Credentials::new("username", "password");
+//! let client = API::new_login("http://qBittorrent.server:6969", cred)
+//!     .await
+//!     .unwrap();
+//!
+//! let torrents = client.torrents(None).await.unwrap();
+//!
+//! for torrent in torrents {
+//!    println!("{}", torrent);
+//! }
+//! ```
+//!
+
 mod client;
 mod error;
 pub(crate) mod utiles;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,18 +11,21 @@
 //! # Example
 //!
 //! Basic usage to get all torrents
-//! ```rust
+//! ```no_run
 //! use qbit::{Api, Credentials};
 //!
-//! let credentials = Credentials::new("username", "password");
-//! let client = API::new_login("http://qBittorrent.server:6969", cred)
-//!     .await
-//!     .unwrap();
+//! #[tokio::main]
+//! async fn main() {
+//!     let credentials = Credentials::new("username", "password");
+//!     let client = Api::new_login("http://qBittorrent.server:6969", credentials)
+//!         .await
+//!         .unwrap();
 //!
-//! let torrents = client.torrents(None).await.unwrap();
+//!     let torrents = client.torrents(None).await.unwrap();
 //!
-//! for torrent in torrents {
-//!    println!("{}", torrent);
+//!     for torrent in torrents {
+//!         println!("{:?}", torrent);
+//!     }
 //! }
 //! ```
 //!

--- a/src/models/creator.rs
+++ b/src/models/creator.rs
@@ -81,7 +81,7 @@ pub struct TorrentCreator {
     pub comment: Option<String>,
 }
 
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Debug, Deserialize, Serialize, Clone)]
 pub struct TorrentCreatorTask {
     /// The task id related to the torrent just created
     #[serde(rename = "taskID")]

--- a/src/models/creator.rs
+++ b/src/models/creator.rs
@@ -5,7 +5,7 @@ use serde::{Deserialize, Serialize};
 
 /// The format of the torrent.
 ///
-/// See https://www.reddit.com/r/qBittorrent/comments/uiwchy/torrent_format_hybrid_v1_and_v2/ for more information
+/// See [torrent format hybrid v1 and v2](https://www.reddit.com/r/qBittorrent/comments/uiwchy/torrent_format_hybrid_v1_and_v2/) for more information
 #[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize, Debug)]
 pub enum TorrentFormat {
     /// Old version, uses SHA-1 for hashing.

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -1,3 +1,10 @@
+//!
+//! This module contains the core models used throughout the application.
+//!
+//! The models defined here are shared across various components and
+//! providing a consistent structure for data representation and serialization.
+//!
+
 use serde::{Deserialize, Serialize};
 
 mod application;

--- a/src/models/torrent.rs
+++ b/src/models/torrent.rs
@@ -51,7 +51,7 @@ pub struct Torrent {
     /// Torrent hash
     pub hash: String,
     /// TODO: need doc block
-    /// I dont know if this is the right filed: https://github.com/qbittorrent/qBittorrent/wiki/WebUI-API-(qBittorrent-5.0)#set-torrent-share-limit
+    /// I dont know if this is the right filed: [#set-torrent-share-limit](https://github.com/qbittorrent/qBittorrent/wiki/WebUI-API-(qBittorrent-5.0)#set-torrent-share-limit)
     pub inactive_seeding_time_limit: i64,
     /// The SHA-1 hash of the torrent's info dictionary (used in BitTorrent v1).
     pub infohash_v1: String,
@@ -60,7 +60,7 @@ pub struct Torrent {
     /// Last time (Unix Epoch) when a chunk was downloaded/uploaded
     pub last_activity: i64,
     /// TODO: need doc block
-    /// I dont know if this is the right filed: https://github.com/qbittorrent/qBittorrent/wiki/WebUI-API-(qBittorrent-5.0)#set-torrent-share-limit
+    /// I dont know if this is the right filed: [#set-torrent-share-limit](https://github.com/qbittorrent/qBittorrent/wiki/WebUI-API-(qBittorrent-5.0)#set-torrent-share-limit)
     pub max_inactive_seeding_time: i64,
     /// Magnet URI corresponding to this torrent
     pub magnet_uri: String,

--- a/src/parameters.rs
+++ b/src/parameters.rs
@@ -1,3 +1,8 @@
+//!
+//! This module provides the data structures and enums necessary for managing
+//! parameters, states, and sorting options.
+//!
+
 use derive_builder::Builder;
 use serde::{Deserialize, Serialize};
 use std::fmt::{Debug, Display};

--- a/tests/torrents/creator.rs
+++ b/tests/torrents/creator.rs
@@ -95,7 +95,7 @@ async fn delete_created_task() {
     assert!(!list.is_empty());
     assert!(list.iter().any(|t| t.task_id == task_id));
     client
-        .delete_task(&task_id)
+        .delete_task(task_id.clone())
         .await
         .expect("Failed to delete task");
     let list = client.list_tasks().await.unwrap();


### PR DESCRIPTION
Implemented minor updates to the documentation as suggested in https://github.com/Mattress237/qbittorrent-webui-api/issues/30#issuecomment-3233938627, by adding examples to all `Api` methods and an introductory section for `docs.rs`. 

Additionally, removed some previously overlooked prefixes in the `torrents` methods.

At the same time, I added a bit more to the `Readme.md`