### PR TITLE
Added missing documenation (and reword some stuff) Part 1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,3 +28,6 @@ rand = "0.9.2"
 
 [lints.clippy]
 uninlined_format_args = "allow"
+
+[lints.rust]
+missing_docs = "deny"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,5 +29,5 @@ rand = "0.9.2"
 [lints.clippy]
 uninlined_format_args = "allow"
 
-[lints.rust]
-missing_docs = "deny"
+# [lints.rust]
+# missing_docs = "deny"

--- a/src/client/application.rs
+++ b/src/client/application.rs
@@ -314,7 +314,7 @@ impl super::Api {
     ///         .unwrap();
     ///
     ///     let cookie = Cookie::default();
-    ///     let result = client.cookies(vec![cookie]).await;
+    ///     let result = client.set_cookies(vec![cookie]).await;
     ///
     ///     assert!(result.is_ok());
     /// }

--- a/src/client/application.rs
+++ b/src/client/application.rs
@@ -10,7 +10,7 @@ use crate::{
 impl super::Api {
     /// Get Qbittorrent application version
     ///
-    /// The response is a string withe the application version, e.g. `v5.1.0`
+    /// The response is a string with the application version, e.g. `v5.1.0`
     ///
     /// [official documentation](https://github.com/qbittorrent/qBittorrent/wiki/WebUI-API-(qBittorrent-5.0)#get-application-version)
     ///

--- a/src/client/application.rs
+++ b/src/client/application.rs
@@ -314,7 +314,7 @@ impl super::Api {
     ///         .unwrap();
     ///
     ///     let cookie = Cookie::default();
-    ///     let result = client.cookies().await;
+    ///     let result = client.cookies(vec![cookie]).await;
     ///
     ///     assert!(result.is_ok());
     /// }
@@ -347,7 +347,7 @@ impl super::Api {
     ///         .await
     ///         .unwrap();
     ///
-    ///     let contents = client.get_directory_contents("dir_path", &DirMode::All)
+    ///     let contents = client.get_directory_contents("/path/to/some/file", &DirMode::All)
     ///         .await
     ///         .unwrap();
     ///

--- a/src/models/application.rs
+++ b/src/models/application.rs
@@ -1,5 +1,6 @@
-use std::{collections::HashMap, default, fmt::Display};
+use std::{collections::HashMap, fmt::Display};
 
+use derive_builder::Builder;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use serde_repr::{Deserialize_repr, Serialize_repr};
 
@@ -20,7 +21,7 @@ pub struct BuildInfo {
     pub bitness: u8,
 }
 /// Preferences response data object.
-#[derive(Debug, Deserialize, Serialize, Clone, Default, PartialEq)]
+#[derive(Debug, Deserialize, Serialize, Clone, Default, PartialEq, Builder)]
 pub struct Preferences {
     // ========== General Settings ==========
     /// Currently selected language (e.g. en_GB for English)

--- a/src/models/application.rs
+++ b/src/models/application.rs
@@ -20,6 +20,7 @@ pub struct BuildInfo {
     /// Application bitness (e.g. 64-bit)
     pub bitness: u8,
 }
+
 /// Preferences response data object.
 #[derive(Debug, Deserialize, Serialize, Clone, Default, PartialEq, Builder)]
 pub struct Preferences {
@@ -32,6 +33,31 @@ pub struct Preferences {
     pub preallocate_all: bool,
     /// Should `.!qb` be added to incomplete files?
     pub incomplete_files_ext: bool,
+    /// Should unchecked files be added to the `.unwanted` folder?
+    ///
+    /// See https://github.com/qbittorrent/qBittorrent/issues/13531 for an argument on the subject.
+    pub use_unwanted_folder: bool,
+    /// Customise the name of the app instance
+    pub app_instance_name: String,
+    /// How often should the UI refresh to get new updates? (in ms)
+    pub refresh_interval: u64,
+    /// Should the client external IP be shown in the status bar?
+    pub status_bar_external_ip: bool,
+    /// Show a confirmation message before deleting a torrent. Does not apply to the API
+    pub confirm_torrent_deletion: bool,
+    /// To delete content files alongside the torrent. A "cache" setting
+    ///
+    /// NOTE: In the webui, this setting is only visible by checking the icon next to the `Also remove content files`
+    /// checkbox upon deleting a file.
+    pub delete_torrent_content_files: bool,
+    /// Show a confirmation message before rechecking a torrent. Does not apply to the API
+    pub confirm_torrent_recheck: bool,
+    /// Allow using of sub-categories. Sub-categories are made by adding `/` between the parent and child.
+    pub use_subcategories: bool,
+    /// Memory usage limit of Physical RAM in MiB
+    ///
+    /// Note: Requires Libtorrent >= 2.0.0
+    pub memory_working_set_limit: u64,
 
     // ========== Torrent Management ==========
     /// Should `Automatic Torrent Mangament` be enabled for new torrents by default?
@@ -56,6 +82,16 @@ pub struct Preferences {
     pub torrent_stop_condition: StopCondition,
     /// What to do with removing torrents.
     pub torrent_content_remove_option: TorrentDeletion,
+    /// If the torrent exists, do we merge trackers with it or fail to add the torrent altogether?
+    pub merge_trackers: bool,
+    /// Use the path specified by the category even if the torrent is in manual mode.
+    pub use_category_paths_in_manual_mode: bool,
+    /// Number of connection attempts made per second.
+    ///
+    /// If number < 0, a default of 200 will be made.
+    pub connection_speed: i64,
+    /// How many torrents can be actively checking at one time.
+    pub max_active_checking_torrents: i64,
 
     // ========== File Paths ==========
     /// Default save path for torrents
@@ -70,6 +106,17 @@ pub struct Preferences {
     pub export_dir: String,
     /// Path to copy `.torrent` files of completed downloads to.
     pub export_dir_fin: String,
+    /// Is the filename blacklist enabled?
+    pub excluded_file_names_enabled: bool,
+    /// Blacklist filter file names from being downloaded from the torrent.
+    ///
+    /// Files matching any of this list will have the priority set to `Do Not Download` by default. (newline separator)
+    ///
+    /// The follow wildcards can be used:
+    /// - *: Any character
+    /// - ?: Any Single character
+    /// - [...]: Sets of characters
+    pub excluded_file_names: String,
 
     // ========== Email Notifications ==========
     /// Should email notifications be sent after a download is finished?
@@ -123,6 +170,14 @@ pub struct Preferences {
     ///
     /// See `autorun_program` for the supported parameters, tips and examples.
     pub autorun_on_torrent_added_program: String,
+    /// Enables Mark-of-the-web. Tells external programs that this file is potentiall unsafe.
+    ///
+    /// Windows (MOTW) and Mac (quarantine) only
+    pub mark_of_the_web: bool,
+    /// Python executable path. For use in stuff like search engine plugins which require python.
+    ///
+    /// Will attempt to find and use a system wide one if nothing is specified.
+    pub python_executable_path: String,
 
     // ========== Queue Management ==========
     /// Is torrent queuing enabled?
@@ -141,6 +196,13 @@ pub struct Preferences {
     pub slow_torrent_ul_rate_threshold: i64,
     /// Seconds a torrent should be inactive before considered "slow"
     pub slow_torrent_inactive_timer: i64,
+    /// To add new torrents to the top of the queue by default or not?
+    pub add_to_top_of_queue: bool,
+    /// Default setting for allowing new torrents to start automatically.
+    ///
+    /// - True = don't start downloading automatically.
+    /// - False = Start downloading automatically.
+    pub add_stopped_enabled: bool,
 
     // ========== Seed Limits ==========
     /// Show an action be taken once the torrent ratio is achieved?
@@ -324,8 +386,6 @@ pub struct Preferences {
     ///
     /// The password is used exclusively for setting or updating the WebUI password.
     pub web_ui_password: Option<String>,
-
-    // ========== WebUI Security ==========
     /// True if WebUI CSRF protection is enabled
     pub web_ui_csrf_protection_enabled: bool,
     /// True if WebUI clickjacking protection is enabled
@@ -350,16 +410,12 @@ pub struct Preferences {
     pub web_ui_reverse_proxy_enabled: bool,
     /// List of trusted proxies to access the webui. Separated by `;`
     pub web_ui_reverse_proxies_list: String,
-
-    // ========== Alternative WebUI ==========
     /// Should an alternative web ui be used?
     ///
     /// NOTE: This is not the same as a theme (`.qbttheme`)
     pub alternative_webui_enabled: bool,
     /// File path to the alternative WebUI
     pub alternative_webui_path: String,
-
-    // ========== WebUI HTTPS ==========
     /// Does the server use HTTPS?
     pub use_https: bool,
     /// For API ≥ v2.0.1: Path to SSL keyfile
@@ -368,8 +424,6 @@ pub struct Preferences {
     ///
     /// See https://httpd.apache.org/docs/current/ssl/ssl_faq.html#aboutcerts for information on certificates.
     pub web_ui_https_cert_path: String,
-
-    // ========== WebUI Custom Headers ==========
     /// For API ≥ v2.5.1: Enable custom http headers
     pub web_ui_use_custom_http_headers_enabled: bool,
     /// For API ≥ v2.5.1: List of custom http headers.
@@ -426,6 +480,8 @@ pub struct Preferences {
     pub announce_ip: String,
     /// The port reported to trackers. 0 uses `listening_port`.
     pub announce_port: u16,
+    /// Tells all trackers when either the IP or Port of our client changes.
+    pub reannounce_when_address_changed: bool,
     /// Always announce to all tiers.
     ///
     /// See https://www.libtorrent.org/reference-Settings.html#announce_to_all_tiers for more information
@@ -434,6 +490,10 @@ pub struct Preferences {
     ///
     /// See https://www.libtorrent.org/reference-Settings.html#announce_to_all_trackers for more information
     pub announce_to_all_trackers: bool,
+    /// Limits the number of concurrent HTTP tracker announces.
+    ///
+    /// See https://www.libtorrent.org/reference-Settings.html#max_concurrent_http_announces for more information.
+    pub max_concurrent_http_announces: i64,
 
     // ========== Advanced Settings ==========
     /// Enables LibTorrent `piece_extent_affinity` setting.
@@ -451,6 +511,8 @@ pub struct Preferences {
     pub current_interface_address: String,
     /// Network Interface used
     pub current_network_interface: String,
+    /// The name of the network interface used.
+    pub current_interface_name: String,
     /// Disk cache used in MiB
     ///
     /// Only supported in LibTorrent < 2.0
@@ -472,6 +534,10 @@ pub struct Preferences {
     ///
     /// See https://www.libtorrent.org/reference-Settings.html#max_queued_disk_bytes for more information.
     pub disk_queue_size: u64,
+    /// Number of threads to use for piece hash verification
+    ///
+    /// See https://www.libtorrent.org/reference-Settings.html#hashing_threads for more information.
+    pub hashing_threads: u64,
 
     /// Enable qbittorrent to become a tracker.
     ///
@@ -490,6 +556,21 @@ pub struct Preferences {
     ///
     /// See https://www.libtorrent.org/reference-Settings.html#allow_multiple_connections_per_ip for more information.
     pub enable_multi_connections_from_same_ip: bool,
+    /// Don't make network requests to peers who ports are < 1024
+    ///
+    /// See https://libtorrent.org/single-page-ref.html#no_connect_privileged_ports for more information
+    pub block_peers_on_privileged_ports: bool,
+    /// Should Server-side request forgery (SSRF) be mitigated?
+    pub ssrf_mitigation: bool,
+    /// Makes the certificate of trackers and web seeds validated against the system certificate.
+    ///
+    /// See https://www.libtorrent.org/reference-Settings.html#validate_https_trackers for more information.
+    pub validate_https_tracker_certificate: bool,
+    /// Allows trackers/web seeds with an internationalised domain name.
+    ///
+    /// See https://www.libtorrent.org/reference-Settings.html#allow_idna for more information.
+    pub idn_support_enabled: bool,
+
     /// Enable sending out a message with recent read pieces of a torrent in order to create a bias.
     ///
     /// See https://www.libtorrent.org/reference-Settings.html#suggest_mode for more information.
@@ -551,6 +632,49 @@ pub struct Preferences {
     ///
     /// See https://www.libtorrent.org/reference-Settings.html#upnp_lease_duration for more information
     pub upnp_lease_duration: u32,
+    /// Specify the max number of nested lists/dictionaries in the data structure
+    ///
+    /// See https://www.libtorrent.org/reference-Bdecoding.html#bdecode() for more information
+    pub bdecode_depth_limit: u64,
+    /// The maximum number of tokens to be parsed from the buffer.
+    ///
+    /// See https://www.libtorrent.org/reference-Bdecoding.html#bdecode() for more information
+    pub bdecode_token_limit: u64,
+    /// Determinds the DSCP field in the IP header
+    ///
+    /// See https://www.libtorrent.org/reference-Settings.html#peer_dscp for more information
+    ///
+    /// Note: Qbittorrent uses the old version of this setting name.
+    #[serde(rename = "peer_tos")]
+    pub peer_dscp: u64,
+    /// Percentage of peers to disconnect every turnover.
+    ///
+    /// See https://www.libtorrent.org/reference-Settings.html#peer_turnover for more information.
+    pub peer_turnover: u64,
+    /// The limit of the maximum limit before turnover starts
+    ///
+    /// See https://www.libtorrent.org/reference-Settings.html#peer_turnover for more information.
+    pub peer_turnover_cutoff: u64,
+    /// How often the turnover occurs
+    ///
+    /// See https://www.libtorrent.org/reference-Settings.html#peer_turnover for more information.
+    pub peer_turnover_interval: u64,
+    /// Affects certification validation and non-torrent activities.
+    pub ignore_ssl_errors: bool,
+    /// Should torrents use SSL connections
+    pub ssl_enabled: bool,
+    /// The port for SSL Torrents to connect to.
+    pub ssl_listen_port: u16,
+    /// What type of storage should be used to save the Fastresume files.
+    pub resume_data_storage_type: FastResumeType,
+    /// CSV of IP port-pairs added to the DHT Node if enabled
+    ///
+    /// See https://www.libtorrent.org/reference-Settings.html#dht_bootstrap_nodes for more information
+    pub dht_bootstrap_nodes: String,
+    /// Maximum number of outstanding requests to send to a peer.
+    ///
+    /// See ttps://www.libtorrent.org/reference-Settings.html#max_out_request_queue for more information.
+    pub request_queue_size: u64,
 
     // ========== File Log Settings ==========
     /// Enable storing logs to disk
@@ -568,6 +692,8 @@ pub struct Preferences {
     pub file_log_age: u64,
     /// The type of age the log needs to be before being deleted.
     pub file_log_age_type: FileAge,
+    /// Log performance warnings as well as everything else.
+    pub performance_warning: bool,
 
     // ========== I2P Settings ==========
     /// Is I2P (Invisible Internet Project) networking enabled?
@@ -974,4 +1100,27 @@ pub enum FileAge {
     Month,
     /// After X years
     Year,
+}
+
+/// The file structure to use for the fastresume file.
+#[derive(Debug, Default, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Clone)]
+pub enum FastResumeType {
+    /// Use the "legacy" file format
+    #[default]
+    Files,
+    /// Use the experimental SQLite Database format.
+    SQLite,
+}
+
+impl std::fmt::Display for FastResumeType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "{}",
+            match self {
+                Self::Files => "Legacy",
+                Self::SQLite => "SQLite",
+            }
+        )
+    }
 }

--- a/src/models/application.rs
+++ b/src/models/application.rs
@@ -549,6 +549,23 @@ pub struct Preferences {
     ///
     /// See https://www.libtorrent.org/reference-Settings.html#upnp_lease_duration for more information
     pub upnp_lease_duration: u32,
+
+    // ========== File Log Settings ==========
+    /// Enable storing logs to disk
+    pub file_log_enabled: bool,
+    /// The folder to store logs to
+    pub file_log_path: String,
+    /// Enable backing up log files when the file gets too big.
+    pub file_log_backup_enabled: bool,
+    /// How big should the log file be before being backed up (in KiB)
+    pub file_log_max_size: u64,
+    /// Should old logs be deleted?
+    pub file_log_delete_old: u64,
+    /// How old does the log need to be before being auto deleted?
+    /// See `file_log_age_type`
+    pub file_log_age: u64,
+    /// The type of age the log needs to be before being deleted.
+    pub file_log_age_type: FileAge,
 }
 
 /// How the torrent content is laied out.
@@ -923,4 +940,16 @@ pub enum DiskIOType {
     /// Use single pread/pwrite operations for reads and writes.
     /// This is a more basic I/O method that performs single-shot read/write calls.
     SinglePReadWrite,
+}
+
+/// The type of age
+#[derive(Debug, Default, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Clone)]
+pub enum FileAge {
+    /// After X days
+    Day,
+    /// After X months
+    #[default]
+    Month,
+    /// After X years
+    Year,
 }

--- a/src/models/application.rs
+++ b/src/models/application.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashMap, fmt::Display};
+use std::{collections::HashMap, default, fmt::Display};
 
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use serde_repr::{Deserialize_repr, Serialize_repr};
@@ -27,9 +27,9 @@ pub struct Preferences {
     pub locale: String,
     /// When (and should) the `.torrent` file be deleted after added.
     pub auto_delete_mode: AutoDeleteMode,
-    /// True if disk space should be pre-allocated for all files
+    /// Should disk space be pre-allocated for all files?
     pub preallocate_all: bool,
-    /// True if ".!qB" should be appended to incomplete files
+    /// Should `.!qb` be added to incomplete files?
     pub incomplete_files_ext: bool,
 
     // ========== Torrent Management ==========
@@ -676,6 +676,8 @@ pub enum UtpTcpMixedMode {
     PreferTcp = 0,
     PeerProportional = 1,
 }
+
+/// Struct containing information about an individual cookie.
 #[derive(Debug, Deserialize, Serialize, Clone, Default, PartialEq)]
 pub struct Cookie {
     /// The name of the cookie.
@@ -691,17 +693,18 @@ pub struct Cookie {
     pub expiration: i64,
 }
 
-#[derive(Debug, Deserialize, Serialize, Clone, PartialEq, Eq, PartialOrd, Ord)]
+/// The type of results to get back whilst doing `get_directory_contents`
+///
+/// Hidden files are not included.
+#[derive(Debug, Deserialize, Serialize, Clone, PartialEq, Eq, PartialOrd, Ord, Default)]
 pub enum DirMode {
+    /// Only return directories
     Dirs,
+    /// Only return files
     Files,
+    /// Returns everything
+    #[default]
     All,
-}
-
-impl Default for DirMode {
-    fn default() -> Self {
-        Self::All
-    }
 }
 
 impl Display for DirMode {

--- a/src/models/application.rs
+++ b/src/models/application.rs
@@ -33,13 +33,19 @@ pub struct Preferences {
     pub incomplete_files_ext: bool,
 
     // ========== Torrent Management ==========
-    /// True if Automatic Torrent Management is enabled by default
+    /// Should `Automatic Torrent Mangament` be enabled for new torrents by default?
     pub auto_tmm_enabled: bool,
-    /// True if torrent should be relocated when its Category changes
+    /// Should the torrent be relocated or switched to manual mode when category is changed?
+    ///
+    /// True = Relocated, False = Manual Mode
     pub torrent_changed_tmm_enabled: bool,
-    /// True if torrent should be relocated when the default save path changes
+    /// Should the affected torrents be relocated or switched to manual mode when the default save/incomplete path is changed?
+    ///
+    /// True = Relocated, False = Manual Mode
     pub save_path_changed_tmm_enabled: bool,
-    /// True if torrent should be relocated when its Category's save path changes
+    /// Should the affected torrents be relocated or switched to manual mode when it's category save path has changed?
+    ///
+    /// True = Relocated, False = Manual Mode
     pub category_changed_tmm_enabled: bool,
     /// The default layout of the torrent content.
     pub torrent_content_layout: ContentLayout,
@@ -51,31 +57,33 @@ pub struct Preferences {
     pub torrent_content_remove_option: TorrentDeletion,
 
     // ========== File Paths ==========
-    /// Default save path for torrents, separated by slashes
+    /// Default save path for torrents
     pub save_path: String,
-    /// True if folder for incomplete torrents is enabled
+    /// Should another path be used for incomplete torrents?
     pub temp_path_enabled: bool,
-    /// Path for incomplete torrents, separated by slashes
+    /// The path to use for incomplete torrents.
     pub temp_path: String,
     // Property: directory to watch for torrent files, value: where torrents loaded from this directory should be downloaded to (see list of possible values below). Slashes are used as path separators; multiple key/value pairs can be specified
     pub scan_dirs: HashMap<String, ScanDir>,
-    /// Path to directory to copy .torrent files to. Slashes are used as path separators
+    /// Path to copy `.torrent` files to.
     pub export_dir: String,
-    /// Path to directory to copy .torrent files of completed downloads to. Slashes are used as path separators
+    /// Path to copy `.torrent` files of completed downloads to.
     pub export_dir_fin: String,
 
     // ========== Email Notifications ==========
-    /// True if e-mail notification should be enabled
+    /// Should email notifications be sent after a download is finished?
     pub mail_notification_enabled: bool,
     /// e-mail where notifications should originate from
+    ///
+    /// Client default: qBittorrent_notification@example.com
     pub mail_notification_sender: String,
     /// e-mail to send notifications to
     pub mail_notification_email: String,
     /// smtp server for e-mail notifications
     pub mail_notification_smtp: String,
-    /// True if smtp server requires SSL connection
+    /// Does the smtp server require a secure connection (SSL)?
     pub mail_notification_ssl_enabled: bool,
-    /// True if smtp server requires authentication
+    /// Does the smtp server require authentication?
     pub mail_notification_auth_enabled: bool,
     /// Username for smtp authentication
     pub mail_notification_username: String,
@@ -83,13 +91,34 @@ pub struct Preferences {
     pub mail_notification_password: String,
 
     // ========== External Programs ==========
-    /// True if external program should be run after torrent has finished downloading
+    /// Should an external program be run after a torrent has completed?
     pub autorun_enabled: bool,
-    /// Program path/name/arguments to run if `autorun_enabled` is enabled; path is separated by slashes; you can use `%f` and `%n` arguments, which will be expanded by qBittorent as path_to_torrent_file and torrent_name (from the GUI; not the .torrent file name) respectively
+    /// Program path/name/arguments to run if `autorun_enabled` is enabled;
+    ///
+    /// Supported parameters (case sensitive)
+    /// - %N: Torrent Name
+    /// - %L: Torrent Category
+    /// - %G: Torrent Tags (CSV)
+    /// - %F: Torrent Content Path (same as root path for multi-file torrents)
+    /// - %R: Torrent Root Path (first torrent subdirectory path)
+    /// - %D: Torrent Save Path
+    /// - %C: Number of files in torrent
+    /// - %Z: Torrent Size (bytes)
+    /// - %T: Current Tracker of Torrent
+    /// - %I: Torrent Hash v1
+    /// - %J: Torrent Hash v2
+    /// - %K: Torrent ID
+    ///
+    /// Tip: Encapsulate parameter with quotation marks to avoid text being cut off at whitespace (e.g., "%N")
+    ///
+    /// # Example
+    /// ```norun
+    /// ./path/to/some/program.sh "%N" "%C"
+    /// ```
     pub autorun_program: String,
 
     // ========== Queue Management ==========
-    /// True if torrent queuing is enabled
+    /// Is torrent queuing enabled?
     pub queueing_enabled: bool,
     /// Maximum number of active simultaneous downloads
     pub max_active_downloads: i64,
@@ -97,7 +126,7 @@ pub struct Preferences {
     pub max_active_torrents: i64,
     /// Maximum number of active simultaneous uploads
     pub max_active_uploads: i64,
-    /// If true torrents w/o any activity (stalled ones) will not be counted towards `max_active_*` limits; see dont_count_slow_torrents for more information
+    /// If true torrents w/o any activity (stalled ones) will not be counted towards `max_active_*` limits
     pub dont_count_slow_torrents: bool,
     /// Download rate in KiB/s for a torrent to be considered "slow"
     pub slow_torrent_dl_rate_threshold: i64,
@@ -408,7 +437,7 @@ pub struct Preferences {
 /// How the torrent content is laied out.
 #[derive(Debug, Deserialize, Serialize, Clone, Default, PartialEq)]
 pub enum ContentLayout {
-    /// Does whatever the server says to do, which by default is Subfolder
+    /// Does whatever the client says to do, which by default is Subfolder
     #[default]
     Original,
     /// In cases of batches, will create a separate subfolder automatically of the batch name.

--- a/src/models/application.rs
+++ b/src/models/application.rs
@@ -4,6 +4,8 @@ use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use serde_repr::{Deserialize_repr, Serialize_repr};
 
 /// Build info response data object.
+///
+/// Contains version information of software used to run qbittorrent.
 #[derive(Debug, Deserialize, Serialize, Clone, Default, PartialEq)]
 pub struct BuildInfo {
     /// QT version

--- a/src/models/application.rs
+++ b/src/models/application.rs
@@ -566,6 +566,26 @@ pub struct Preferences {
     pub file_log_age: u64,
     /// The type of age the log needs to be before being deleted.
     pub file_log_age_type: FileAge,
+
+    // ========== I2P Settings ==========
+    /// Is I2P (Invisible Internet Project) networking enabled?
+    ///
+    /// NOTE: This is experimental!
+    pub i2p_enabled: bool,
+    /// I2P SAM bridge address
+    pub i2p_address: String,
+    /// I2P SAM bridge port
+    pub i2p_port: u16,
+    /// Should I2P mixed mode be enabled? (allows both I2P and regular connections)
+    pub i2p_mixed_mode: bool,
+    /// Length of inbound I2P tunnels (number of hops)
+    pub i2p_inbound_length: u64,
+    /// Number of inbound I2P tunnels to create
+    pub i2p_inbound_quantity: u64,
+    /// Length of outbound I2P tunnels (number of hops)
+    pub i2p_outbound_length: u64,
+    /// Number of outbound I2P tunnels to create
+    pub i2p_outbound_quantity: u64,
 }
 
 /// How the torrent content is laied out.

--- a/src/models/application.rs
+++ b/src/models/application.rs
@@ -184,11 +184,13 @@ pub struct Preferences {
     /// Maximum global number of simultaneous connections
     ///
     /// `-1` means disabled
-    pub max_connec: i64,
+    #[serde(rename = "max_connec")]
+    pub max_connections: i64,
     /// Maximum number of simultaneous connections per torrent
     ///
     /// `-1` means disabled
-    pub max_connec_per_torrent: i64,
+    #[serde(rename = "max_connec_per_torrent")]
+    pub max_connections_per_torrent: i64,
     /// Maximum number of upload slots
     ///
     /// `-1` means disabled

--- a/src/models/application.rs
+++ b/src/models/application.rs
@@ -463,8 +463,10 @@ pub struct Preferences {
     pub disk_io_read_mode: DiskRead,
     /// Is the OS allowed to cache write data to files?
     pub disk_io_write_mode: DiskWrite,
+    /// Configure how libtorrent should perform disk I/O for reading and writing
+    /// torrent data.
+    ///
     /// See: https://www.libtorrent.org/single-page-ref.html#default-disk-io-constructor
-    /// (i can't work out how to explain this!)
     pub disk_io_type: DiskIOType,
     /// Maximum number of bytes that can wait in the I/O thread queue.
     ///

--- a/src/models/application.rs
+++ b/src/models/application.rs
@@ -471,71 +471,83 @@ pub struct Preferences {
     /// See https://www.libtorrent.org/reference-Settings.html#max_queued_disk_bytes for more information.
     pub disk_queue_size: u64,
 
-    /// Port used for embedded tracker
-    pub embedded_tracker_port: u16,
-    /// True enables coalesce reads & writes
-    pub enable_coalesce_read_write: bool,
-    /// True enables embedded tracker
-    pub enable_embedded_tracker: bool,
-    /// True allows multiple connections from the same IP address
-    pub enable_multi_connections_from_same_ip: bool,
-    /// True enables sending of upload piece suggestions
-    pub enable_upload_suggestions: bool,
-    /// File pool size
+    /// Enable qbittorrent to become a tracker.
     ///
-    /// Sets the upper limit on the total number of files this session will keep open.
-    /// The reason why files are left open at all is that some anti virus software hooks
-    /// on every file close, and scans the file for viruses. deferring the closing of
-    /// the files will be the difference between a usable system and a completely hogged
-    /// down system. Most operating systems also has a limit on the total number of file
-    /// descriptors a process may have open.
+    /// See https://github.com/qbittorrent/qBittorrent/wiki/How-to-use-qBittorrent-as-a-tracker for more information.
+    pub enable_embedded_tracker: bool,
+    /// The port used for the embedded tracker.
+    pub embedded_tracker_port: u16,
+    /// Enables the embedded tracker to use port forwarding.
+    pub embedded_tracker_port_forwarding: bool,
+
+    /// Enable coalesce read/writes
+    ///
+    /// Requires LibTorrent < 2.0.0
+    pub enable_coalesce_read_write: bool,
+    /// Allows multiple connections from the same IP address.
+    ///
+    /// See https://www.libtorrent.org/reference-Settings.html#allow_multiple_connections_per_ip for more information.
+    pub enable_multi_connections_from_same_ip: bool,
+    /// Enable sending out a message with recent read pieces of a torrent in order to create a bias.
+    ///
+    /// See https://www.libtorrent.org/reference-Settings.html#suggest_mode for more information.
+    pub enable_upload_suggestions: bool,
+    /// The maximum number of files this session will keep open.
+    ///
+    /// See https://www.libtorrent.org/reference-Settings.html#file_pool_size for more information.
     pub file_pool_size: i64,
     /// Maximal outgoing port (0: Disabled)
+    ///
+    /// See https://www.libtorrent.org/reference-Settings.html#outgoing_port for more information
     pub outgoing_ports_max: u16,
     /// Minimal outgoing port (0: Disabled)
+    ///
+    /// See https://www.libtorrent.org/reference-Settings.html#outgoing_port for more information
     pub outgoing_ports_min: u16,
-    /// True rechecks torrents on completion
+    /// Recheck the torrent upon the torrent being completed.
     pub recheck_completed_torrents: bool,
     /// True resolves peer countries
     pub resolve_peer_countries: bool,
-    /// Save resume data interval in min
-    pub save_resume_data_interval: i64,
-    /// Send buffer low watermark in KiB
+    /// How often the `fastresume` file is saved (in minutes). 0 = disabled
+    pub save_resume_data_interval: u64,
+    /// How often the `statistics` file is saved (in minutes). 0 = disabled
+    pub save_statistics_interval: u64,
+    /// Send buffer low watermark in KiB. The minimum send buffer target size (includes bytes pending read from disk); for snappy seeding set this high enough to fit a few blocks.
     ///
-    /// The minimum send buffer target size (send buffer includes bytes pending being
-    /// read from disk). For good and snappy seeding performance, set this fairly high,
-    /// to at least fit a few blocks. This is essentially the initial window size
-    /// which will determine how fast we can ramp up the send rate
+    /// See https://www.libtorrent.org/reference-Settings.html#send_buffer_low_watermark for more information
     pub send_buffer_low_watermark: i64,
-    /// Send buffer watermark in KiB
+    /// Send buffer watermark in KiB. If the send buffer has fewer bytes than this value, another block will be read onto it; setting it too small hurts upload capacity, too large wastes memory.
     ///
-    /// if the send buffer has fewer bytes than send_buffer_watermark, we'll read
-    /// another 16 kiB block onto it. If set too small, upload rate capacity will
-    /// suffer. If set too high, memory will be wasted. The actual watermark may be
-    /// lower than this in case the upload rate is low, this is the upper limit.
+    /// See https://www.libtorrent.org/reference-Settings.html#send_buffer_watermark for more information
     pub send_buffer_watermark: i64,
-    /// Send buffer watermark factor in percent
+    /// Send buffer watermark factor in percent. The current upload rate to a peer is multiplied by this percentage to derive the watermark (clamped to send_buffer_watermark); higher values can improve throughput but may waste RAM.
     ///
-    /// the current upload rate to a peer is multiplied by this factor to get the
-    /// send buffer watermark. The factor is specified as a percentage. i.e.
-    /// 50 -> 0.5 This product is clamped to the send_buffer_watermark setting to
-    /// not exceed the max. For high speed upload, this should be set to a greater
-    /// value than 100. For high capacity connections, setting this higher can
-    /// improve upload performance and disk throughput. Setting it too high may
-    /// waste RAM and create a bias towards read jobs over write jobs.
+    /// See https://www.libtorrent.org/reference-Settings.html#send_buffer_watermark_factor for more information
     pub send_buffer_watermark_factor: i64,
-    /// Socket backlog size
-    pub socket_backlog_size: i64,
-    /// Upload choking algorithm used (see list of possible values below)
-    pub upload_choking_algorithm: UploadChokingAlgorithm,
-    /// Upload slots behavior used (see list of possible values below)
-    pub upload_slots_behavior: UploadSlotsBehavior,
-    /// upnp lease duration (0: Permanent lease)
+    /// Number of outstanding incoming connections to queue whilst not actively waiting for one to be accepted
     ///
-    /// The expiration time of upnp port-mappings, specified in seconds. 0 means
-    /// permanent lease. Some routers do not support expiration times on port-maps
-    /// (nor correctly returning an error indicating lack of support). In those
-    /// cases, set this to 0. Otherwise, don't set it any lower than 5 minutes.
+    /// See https://www.libtorrent.org/reference-Settings.html#listen_queue_size for more information
+    pub socket_backlog_size: i64,
+    /// Specify the buffer size on receiving peer sockets. 0 = system default.
+    ///
+    /// See https://www.libtorrent.org/reference-Settings.html#send_socket_buffer_size for more information
+    pub socket_send_buffer_size: u64,
+    /// Specify the buffer size on sending peer sockets. 0 = system default.
+    ///
+    /// See https://www.libtorrent.org/reference-Settings.html#send_socket_buffer_size for more information
+    pub socket_receive_buffer_size: u64,
+
+    /// Controls the bahviour of unchocking. How peers are selected
+    ///
+    /// Read more: https://transfercloud.io/blog/2024/02/26/what-is-torrent-chokin/
+    pub upload_choking_algorithm: UploadChokingAlgorithm,
+    /// Specify which algorithm to use to determine how many peers to unchoke.
+    ///
+    /// See https://www.libtorrent.org/reference-Settings.html#choking_algorithm for more information
+    pub upload_slots_behavior: UploadSlotsBehavior,
+    /// upnp lease duration specified in seconds (0: Permanent lease)
+    ///
+    /// See https://www.libtorrent.org/reference-Settings.html#upnp_lease_duration for more information
     pub upnp_lease_duration: u32,
 }
 
@@ -777,26 +789,44 @@ pub enum DyndnsService {
 #[repr(u8)]
 pub enum UploadChokingAlgorithm {
     #[default]
+    /// Rotate unchoked peers in a round-robin fashion, giving each peer a fair chance to upload.
     RoundRobin = 0,
+    /// Prefer peers that currently offer the fastest upload throughput to maximise overall upload performance.
     FastestUpload = 1,
+    /// Use anti-leech heuristics to deprioritize peers that do not contribute, favouring peers that upload data back.
     AntiLeech = 2,
 }
 
-/// Upload slots behavior
+/// Algorithm to use for unchoking peers.
 #[derive(Debug, Deserialize_repr, Serialize_repr, Clone, Default, PartialEq)]
 #[repr(u8)]
 pub enum UploadSlotsBehavior {
     #[default]
+    /// Unchokes a fixed amount of seeders
     Fixed = 0,
+    /// Opens up slots based on the upload rate achieved to peers.
     UploadRate = 1,
 }
 
-/// Mix mode UTP / TCP
+/// μTP / TCP mixed-mode algorithm selection.
+///
+/// This setting controls how the client mixes uTP and TCP connections when both
+/// protocols are available. It determines the preference or distribution of
+/// connection attempts between the two transport protocols.
 #[derive(Debug, Deserialize_repr, Serialize_repr, Clone, Default, PartialEq)]
 #[repr(u8)]
 pub enum UtpTcpMixedMode {
+    /// Prefer TCP connections when both TCP and uTP are available.
+    ///
+    /// When this mode is selected, the client will favour establishing TCP
+    /// connections over uTP ones whenever possible.
     #[default]
     PreferTcp = 0,
+    /// Distribute connections proportionally based on peer capabilities.
+    ///
+    /// In this mode the client attempts to balance or proportion connections
+    /// between TCP and uTP according to peer availability and characteristics,
+    /// rather than strictly preferring one protocol.
     PeerProportional = 1,
 }
 
@@ -872,15 +902,25 @@ pub enum DiskWrite {
     WriteThrough,
 }
 
+/// Disk I/O constructor selection.
+///
 /// See: https://www.libtorrent.org/single-page-ref.html#default-disk-io-constructor
 ///
-/// Enum values gotten from VueTorrent.
+/// Enum values sourced from VueTorrent. Choose how libtorrent should perform
+/// disk I/O for reading and writing torrent data.
 #[derive(Debug, Default, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Clone)]
 pub enum DiskIOType {
-    /// Uses Memory Mapped, otherwise POSIX.
+    /// Use the library's default behaviour: memory-mapped I/O when available,
+    /// otherwise fall back to POSIX-based I/O.
     #[default]
     Default,
+    /// Use memory-mapped files (mmap) for disk I/O. This can improve performance
+    /// by mapping file contents directly into memory.
     MemoryMappedFiles,
-    POSIX_compliant,
+    /// Use POSIX-compliant file I/O methods. This variant selects a POSIX-style
+    /// approach (e.g., pread/pwrite semantics) for compatibility on POSIX systems.
+    PosixComplaint,
+    /// Use single pread/pwrite operations for reads and writes.
+    /// This is a more basic I/O method that performs single-shot read/write calls.
     SinglePReadWrite,
 }

--- a/src/models/application.rs
+++ b/src/models/application.rs
@@ -160,7 +160,7 @@ pub struct Preferences {
     /// Tip: Encapsulate parameter with quotation marks to avoid text being cut off at whitespace (e.g., "%N")
     ///
     /// # Example
-    /// ```norun
+    /// ```sh
     /// ./path/to/some/program.sh "%N" "%C"
     /// ```
     pub autorun_program: String,

--- a/src/models/application.rs
+++ b/src/models/application.rs
@@ -25,8 +25,8 @@ pub struct Preferences {
     // ========== General Settings ==========
     /// Currently selected language (e.g. en_GB for English)
     pub locale: String,
-    /// TODO
-    pub auto_delete_mode: u8,
+    /// When (and should) the `.torrent` file be deleted after added.
+    pub auto_delete_mode: AutoDeleteMode,
     /// True if disk space should be pre-allocated for all files
     pub preallocate_all: bool,
     /// True if ".!qB" should be appended to incomplete files
@@ -449,6 +449,18 @@ impl std::fmt::Display for StopCondition {
             StopCondition::FilesChecked => write!(f, "FilesChecked"),
         }
     }
+}
+
+/// Whether the `.torrent` file should be deleted after the torrent is added.
+#[derive(Debug, Serialize, Deserialize, Clone, Default, PartialEq)]
+pub enum AutoDeleteMode {
+    /// Never delete the `.torrent` file.
+    #[default]
+    Never,
+    /// Only delete the `.torrent` file if the torrent is added.
+    IfAdded,
+    /// Always delete the `.torrent` file.
+    Always,
 }
 
 /// What to do when removing content files upon removing a torrent.


### PR DESCRIPTION
> I can have a go at trying to get most of those errors documented if you want. (Would just have to rattle my wiki brain to produce documentation of stuff i'm semi--familiar in.)

I wrote that, thinking i could knock it all out in a day... No, no i can't.

After a lot of research (a couple of code editor crashes... ), cross checking between `qbittorrent` docs/source. `vuetorrent`, `libtorrent`. All the documenation for `Application` related stuff has been completed. This also includes 80+ undocumented fields that weren't in there originally.

I've split this up, into (hopefully just 2) multiple parts because of some minor API changes (just naming of some already existing enums to make them more accurate)).
> If you want to feel free, but what's missing here can probably just be added with a patch later in 0.2.x.

I haven't had a look at the rest of the docs yet, but hopefully they should be fine to come in an `0.2.x` version. The api changes in this one, are some which just fells like they would fit better in `0.2`

The other tiny changes is just fixing some logically errors with the examples. The `missing_docs` lint is commented out just as a means of convience.


Note to self: Take more breaks when adding in 80+ undocumented entries...