### PR TITLE
The other half of #34. 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,5 +29,5 @@ rand = "0.9.2"
 [lints.clippy]
 uninlined_format_args = "allow"
 
-# [lints.rust]
-# missing_docs = "deny"
+[lints.rust]
+missing_docs = "deny"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,4 +30,4 @@ rand = "0.9.2"
 uninlined_format_args = "allow"
 
 [lints.rust]
-missing_docs = "deny"
+# missing_docs = "deny"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,3 +28,6 @@ rand = "0.9.2"
 
 [lints.clippy]
 uninlined_format_args = "allow"
+
+[lints.rust]
+missing_docs = "deny"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,4 +30,4 @@ rand = "0.9.2"
 uninlined_format_args = "allow"
 
 [lints.rust]
-# missing_docs = "deny"
+missing_docs = "deny"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,5 +29,5 @@ rand = "0.9.2"
 [lints.clippy]
 uninlined_format_args = "allow"
 
-[lints.rust]
-missing_docs = "deny"
+# [lints.rust]
+# missing_docs = "deny"

--- a/src/client/application.rs
+++ b/src/client/application.rs
@@ -22,7 +22,7 @@ impl super::Api {
     /// #[tokio::main]
     /// async fn main() {
     ///     let credentials = Credentials::new("username", "password");
-    ///     let client = Api::new_login("url", credentials)
+    ///     let client = Api::new_login("http://127.0.0.1/", credentials)
     ///         .await
     ///         .unwrap();
     ///
@@ -58,7 +58,7 @@ impl super::Api {
     /// #[tokio::main]
     /// async fn main() {
     ///     let credentials = Credentials::new("username", "password");
-    ///     let client = Api::new_login("url", credentials)
+    ///     let client = Api::new_login("http://127.0.0.1/", credentials)
     ///         .await
     ///         .unwrap();
     ///
@@ -92,7 +92,7 @@ impl super::Api {
     /// #[tokio::main]
     /// async fn main() {
     ///     let credentials = Credentials::new("username", "password");
-    ///     let client = Api::new_login("url", credentials)
+    ///     let client = Api::new_login("http://127.0.0.1/", credentials)
     ///         .await
     ///         .unwrap();
     ///
@@ -126,7 +126,7 @@ impl super::Api {
     /// #[tokio::main]
     /// async fn main() {
     ///     let credentials = Credentials::new("username", "password");
-    ///     let client = Api::new_login("url", credentials)
+    ///     let client = Api::new_login("http://127.0.0.1/", credentials)
     ///         .await
     ///         .unwrap();
     ///
@@ -157,7 +157,7 @@ impl super::Api {
     /// #[tokio::main]
     /// async fn main() {
     ///     let credentials = Credentials::new("username", "password");
-    ///     let client = Api::new_login("url", credentials)
+    ///     let client = Api::new_login("http://127.0.0.1/", credentials)
     ///         .await
     ///         .unwrap();
     ///
@@ -192,7 +192,7 @@ impl super::Api {
     /// #[tokio::main]
     /// async fn main() {
     ///     let credentials = Credentials::new("username", "password");
-    ///     let client = Api::new_login("url", credentials)
+    ///     let client = Api::new_login("http://127.0.0.1/", credentials)
     ///         .await
     ///         .unwrap();
     ///
@@ -228,7 +228,7 @@ impl super::Api {
     /// #[tokio::main]
     /// async fn main() {
     ///     let credentials = Credentials::new("username", "password");
-    ///     let client = Api::new_login("url", credentials)
+    ///     let client = Api::new_login("http://127.0.0.1/", credentials)
     ///         .await
     ///         .unwrap();
     ///
@@ -264,7 +264,7 @@ impl super::Api {
     /// #[tokio::main]
     /// async fn main() {
     ///     let credentials = Credentials::new("username", "password");
-    ///     let client = Api::new_login("url", credentials)
+    ///     let client = Api::new_login("http://127.0.0.1/", credentials)
     ///         .await
     ///         .unwrap();
     ///
@@ -309,7 +309,7 @@ impl super::Api {
     /// #[tokio::main]
     /// async fn main() {
     ///     let credentials = Credentials::new("username", "password");
-    ///     let client = Api::new_login("url", credentials)
+    ///     let client = Api::new_login("http://127.0.0.1/", credentials)
     ///         .await
     ///         .unwrap();
     ///
@@ -343,7 +343,7 @@ impl super::Api {
     /// #[tokio::main]
     /// async fn main() {
     ///     let credentials = Credentials::new("username", "password");
-    ///     let client = Api::new_login("url", credentials)
+    ///     let client = Api::new_login("http://127.0.0.1/", credentials)
     ///         .await
     ///         .unwrap();
     ///

--- a/src/client/authentication.rs
+++ b/src/client/authentication.rs
@@ -3,9 +3,7 @@ use reqwest::header::{self};
 use crate::{Credentials, LoginState, error::Error};
 
 impl super::Api {
-    /// Create a new API instance and login to the service.
-    ///
-    /// This method allows you to create a new API instance and login using the provided credentials.s
+    /// Create a new API instance and login to qbittorrent with the provided credentials.
     ///
     /// # Arguments
     /// * `url` - The base URL of the API service.
@@ -19,7 +17,7 @@ impl super::Api {
     /// #[tokio::main]
     /// async fn main() {
     ///     let credentials = Credentials::new("username", "password");
-    ///     let client = Api::new_login("url", credentials)
+    ///     let client = Api::new_login("http://127.0.0.1/", credentials)
     ///         .await
     ///         .unwrap();
     /// }
@@ -36,7 +34,7 @@ impl super::Api {
         Ok(api)
     }
 
-    /// Create a new API instance and login to the service with username and password.
+    /// Create a new API instance and login to the service with the provided username and password.
     ///
     /// # Arguments
     /// * `url` - The base URL of the API service.
@@ -50,7 +48,7 @@ impl super::Api {
     ///
     /// #[tokio::main]
     /// async fn main() {
-    ///     let client = Api::new_login_username_password("url", "username", "password")
+    ///     let client = Api::new_login_username_password("http://127.0.0.1/", "username", "password")
     ///         .await
     ///         .unwrap();
     /// }
@@ -84,7 +82,7 @@ impl super::Api {
     /// #[tokio::main]
     /// async fn main() {
     ///     let credentials = Credentials::new("username", "password");
-    ///     let mut client = Api::new_login("url", credentials)
+    ///     let mut client = Api::new_login("http://127.0.0.1/", credentials)
     ///         .await
     ///         .unwrap();
     ///
@@ -161,9 +159,7 @@ impl super::Api {
         Ok(())
     }
 
-    /// Login to the service.
-    ///
-    /// This method allows you to create a new API instance and login using an existing SID cookie.
+    /// Login to the service by providing an existing valid SID (Session identifier) cookie.
     ///
     /// # Arguments
     /// * `url` - The base URL of the API service.
@@ -176,7 +172,7 @@ impl super::Api {
     ///
     /// #[tokio::main]
     /// async fn main() {
-    ///     let client = Api::new_from_cookie("url", "cookie")
+    ///     let client = Api::new_from_cookie("http://127.0.0.1/", "cookie")
     ///         .await
     ///         .unwrap();
     /// }
@@ -211,7 +207,7 @@ impl super::Api {
     /// #[tokio::main]
     /// async fn main() {
     ///     let credentials = Credentials::new("username", "password");
-    ///     let client = Api::new_login("url", credentials)
+    ///     let client = Api::new_login("http://127.0.0.1", credentials)
     ///         .await
     ///         .unwrap();
     ///

--- a/src/client/creator.rs
+++ b/src/client/creator.rs
@@ -27,6 +27,7 @@ impl super::Api {
     ///     let result = client.create_task(&torrent).await;
     ///
     ///     assert!(result.is_ok());
+    ///     println!("{}", result.ok().task_id);
     /// }
     /// ```
     pub async fn create_task(&self, params: &TorrentCreator) -> Result<TorrentCreatorTask, Error> {
@@ -111,7 +112,7 @@ impl super::Api {
             .await?)
     }
 
-    /// Get the `.torrent` file for a given task id. (Task must have finished)
+    /// Get the `.torrent` file for a given task id. (Task must be finished)
     ///
     /// # Example
     ///
@@ -173,7 +174,9 @@ impl super::Api {
     ///         .await
     ///         .unwrap();
     ///
-    ///     let result = client.delete_task("task_id".to_string()).await;
+    ///     let torrent = TorrentCreator::default();
+    ///     let torrent_task = client.create_task(&torrent).await;
+    ///     let result = client.delete_task(torrent_task).await;
     ///
     ///     assert!(result.is_ok());
     /// }

--- a/src/client/creator.rs
+++ b/src/client/creator.rs
@@ -27,7 +27,7 @@ impl super::Api {
     ///     let result = client.create_task(&torrent).await;
     ///
     ///     assert!(result.is_ok());
-    ///     println!("{}", result.ok().task_id);
+    ///     println!("{}", result.ok().unwrap().task_id);
     /// }
     /// ```
     pub async fn create_task(&self, params: &TorrentCreator) -> Result<TorrentCreatorTask, Error> {
@@ -166,6 +166,7 @@ impl super::Api {
     ///
     /// ```no_run
     /// use qbit::{Api, Credentials};
+    /// use qbit::models::TorrentCreator;
     ///
     /// #[tokio::main]
     /// async fn main() {
@@ -175,7 +176,7 @@ impl super::Api {
     ///         .unwrap();
     ///
     ///     let torrent = TorrentCreator::default();
-    ///     let torrent_task = client.create_task(&torrent).await;
+    ///     let torrent_task = client.create_task(&torrent).await.unwrap();
     ///     let result = client.delete_task(torrent_task).await;
     ///
     ///     assert!(result.is_ok());

--- a/src/client/creator.rs
+++ b/src/client/creator.rs
@@ -19,7 +19,7 @@ impl super::Api {
     /// #[tokio::main]
     /// async fn main() {
     ///     let credentials = Credentials::new("username", "password");
-    ///     let client = Api::new_login("url", credentials)
+    ///     let client = Api::new_login("http://127.0.0.1/", credentials)
     ///         .await
     ///         .unwrap();
     ///
@@ -90,7 +90,7 @@ impl super::Api {
     /// #[tokio::main]
     /// async fn main() {
     ///     let credentials = Credentials::new("username", "password");
-    ///     let client = Api::new_login("url", credentials)
+    ///     let client = Api::new_login("http://127.0.0.1/", credentials)
     ///         .await
     ///         .unwrap();
     ///
@@ -123,7 +123,7 @@ impl super::Api {
     /// #[tokio::main]
     /// async fn main() {
     ///     let credentials = Credentials::new("username", "password");
-    ///     let client = Api::new_login("url", credentials)
+    ///     let client = Api::new_login("http://127.0.0.1/", credentials)
     ///         .await
     ///         .unwrap();
     ///
@@ -170,7 +170,7 @@ impl super::Api {
     /// #[tokio::main]
     /// async fn main() {
     ///     let credentials = Credentials::new("username", "password");
-    ///     let client = Api::new_login("url", credentials)
+    ///     let client = Api::new_login("http://127.0.0.1/", credentials)
     ///         .await
     ///         .unwrap();
     ///

--- a/src/client/log.rs
+++ b/src/client/log.rs
@@ -6,8 +6,6 @@ use crate::{
 };
 
 impl super::Api {
-    /// Get log
-    ///
     /// Retrieves the main log of the qBittorrent application.
     ///
     /// [official documentation](https://github.com/qbittorrent/qBittorrent/wiki/WebUI-API-(qBittorrent-5.0)#get-log)
@@ -16,6 +14,7 @@ impl super::Api {
     ///
     /// * `last_known_id` - Exclude messages with "message id" <= `last_known_id` (default: `-1`)
     /// * `log_types` - List of desierd log types. (default: all)
+    ///     Doesn't matter if multiple of the same type are provided as only one will be counted in the end.
     ///
     /// # Example
     ///
@@ -66,8 +65,6 @@ impl super::Api {
         Ok(log)
     }
 
-    /// Get peer log
-    ///
     /// Retrieves the peer log of the qBittorrent application.
     ///
     /// [official documentation](https://github.com/qbittorrent/qBittorrent/wiki/WebUI-API-(qBittorrent-5.0)#get-peer-log)

--- a/src/client/log.rs
+++ b/src/client/log.rs
@@ -25,7 +25,7 @@ impl super::Api {
     /// #[tokio::main]
     /// async fn main() {
     ///     let credentials = Credentials::new("username", "password");
-    ///     let client = Api::new_login("url", credentials)
+    ///     let client = Api::new_login("http://127.0.0.1/", credentials)
     ///         .await
     ///         .unwrap();
     ///
@@ -81,7 +81,7 @@ impl super::Api {
     /// #[tokio::main]
     /// async fn main() {
     ///     let credentials = Credentials::new("username", "password");
-    ///     let client = Api::new_login("url", credentials)
+    ///     let client = Api::new_login("http://127.0.0.1/", credentials)
     ///         .await
     ///         .unwrap();
     ///

--- a/src/client/log.rs
+++ b/src/client/log.rs
@@ -6,7 +6,7 @@ use crate::{
 };
 
 impl super::Api {
-    /// Retrieves the main log of the qBittorrent application.
+    /// Retrieves the main log (application log)
     ///
     /// [official documentation](https://github.com/qbittorrent/qBittorrent/wiki/WebUI-API-(qBittorrent-5.0)#get-log)
     ///
@@ -64,7 +64,7 @@ impl super::Api {
         Ok(log)
     }
 
-    /// Retrieves the peer log of the qBittorrent application.
+    /// Retrieves the peer log
     ///
     /// [official documentation](https://github.com/qbittorrent/qBittorrent/wiki/WebUI-API-(qBittorrent-5.0)#get-peer-log)
     ///

--- a/src/client/log.rs
+++ b/src/client/log.rs
@@ -13,8 +13,7 @@ impl super::Api {
     /// # Arguments
     ///
     /// * `last_known_id` - Exclude messages with "message id" <= `last_known_id` (default: `-1`)
-    /// * `log_types` - List of desierd log types. (default: all)
-    ///     Doesn't matter if multiple of the same type are provided as only one will be counted in the end.
+    /// * `log_types` - List of desierd log types. (default: all). Doesn't matter if multiple of the same type are provided as only one will be counted in the end.
     ///
     /// # Example
     ///

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -44,10 +44,14 @@ impl Api {
         Ok(url)
     }
 
+    /// Returns the current session identifier cookie (if it exists).
     pub async fn get_sid_cookie(&self) -> Option<String> {
         self.state.read().await.as_cookie()
     }
 
+    /// Sets the current session identifier cookie.
+    ///
+    /// This will also change the state of the client.
     pub async fn set_sid_cookie(&mut self, value: impl Into<&str>) -> Result<(), Error> {
         let new_state = self.state.read().await.add_cookie(value.into());
 

--- a/src/client/rss.rs
+++ b/src/client/rss.rs
@@ -8,7 +8,7 @@ use crate::{
 };
 
 impl super::Api {
-    /// Add RSS folder
+    /// Add RSS folder to help categorise torrents.
     ///
     /// [official documentation](https://github.com/qbittorrent/qBittorrent/wiki/WebUI-API-(qBittorrent-5.0)#add-folder)
     ///
@@ -24,7 +24,7 @@ impl super::Api {
     /// #[tokio::main]
     /// async fn main() {
     ///     let credentials = Credentials::new("username", "password");
-    ///     let client = Api::new_login("url", credentials)
+    ///     let client = Api::new_login("http://127.0.0.1/", credentials)
     ///         .await
     ///         .unwrap();
     ///
@@ -62,12 +62,14 @@ impl super::Api {
     /// #[tokio::main]
     /// async fn main() {
     ///     let credentials = Credentials::new("username", "password");
-    ///     let client = Api::new_login("url", credentials)
+    ///     let client = Api::new_login("http://127.0.0.1/", credentials)
     ///         .await
     ///         .unwrap();
     ///
+    ///     client.rss_add_folder("folder").await.unwrap();
+    ///
     ///     let feed = "http://thepiratebay.org/rss//top100/200";
-    ///     let result = client.rss_add_feed(feed, Some("add\\it\\here")).await;
+    ///     let result = client.rss_add_feed(feed, Some("folder")).await;
     ///
     ///     assert!(result.is_ok());
     /// }
@@ -88,9 +90,7 @@ impl super::Api {
         Ok(())
     }
 
-    /// Remove RSS item
-    ///
-    /// Removes folder or feed.
+    /// Removes folder or rss feed.
     ///
     /// [official documentation](https://github.com/qbittorrent/qBittorrent/wiki/WebUI-API-(qBittorrent-5.0)#remove-item)
     ///
@@ -105,7 +105,7 @@ impl super::Api {
     /// #[tokio::main]
     /// async fn main() {
     ///     let credentials = Credentials::new("username", "password");
-    ///     let client = Api::new_login("url", credentials)
+    ///     let client = Api::new_login("http://127.0.0.1/", credentials)
     ///         .await
     ///         .unwrap();
     ///
@@ -127,8 +127,6 @@ impl super::Api {
         Ok(())
     }
 
-    /// Move RSS item
-    ///
     /// Moves/renames folder or feed.
     ///
     /// [official documentation](https://github.com/qbittorrent/qBittorrent/wiki/WebUI-API-(qBittorrent-5.0)#move-item)
@@ -145,7 +143,7 @@ impl super::Api {
     /// #[tokio::main]
     /// async fn main() {
     ///     let credentials = Credentials::new("username", "password");
-    ///     let client = Api::new_login("url", credentials)
+    ///     let client = Api::new_login("http://127.0.0.1/", credentials)
     ///         .await
     ///         .unwrap();
     ///
@@ -175,7 +173,7 @@ impl super::Api {
     ///
     /// # Arguments
     ///
-    /// * `withData` - True if you need current feed articles
+    /// * `withData` - Also return the articles of every feed.
     ///
     /// # Returns
     /// A `HashMap` where the keys are feed names and the values are `RssFeedCollection` objects.
@@ -190,7 +188,7 @@ impl super::Api {
     /// #[tokio::main]
     /// async fn main() {
     ///     let credentials = Credentials::new("username", "password");
-    ///     let client = Api::new_login("url", credentials)
+    ///     let client = Api::new_login("http://127.0.0.1/", credentials)
     ///         .await
     ///         .unwrap();
     ///
@@ -220,7 +218,7 @@ impl super::Api {
         Ok(feed)
     }
 
-    /// Mark as read
+    /// Mark article / folder / feed as read
     ///
     /// If `article_id` is set only the article is marked as read otherwise the whole
     /// feed is going to be marked as read.
@@ -239,7 +237,7 @@ impl super::Api {
     /// #[tokio::main]
     /// async fn main() {
     ///     let credentials = Credentials::new("username", "password");
-    ///     let client = Api::new_login("url", credentials)
+    ///     let client = Api::new_login("http://127.0.0.1/", credentials)
     ///         .await
     ///         .unwrap();
     ///
@@ -264,8 +262,6 @@ impl super::Api {
         Ok(())
     }
 
-    /// Refresh RSS item
-    ///
     /// Refreshes folder or feed.
     ///
     /// [official documentation](https://github.com/qbittorrent/qBittorrent/wiki/WebUI-API-(qBittorrent-5.0)#refresh-item)
@@ -281,7 +277,7 @@ impl super::Api {
     /// #[tokio::main]
     /// async fn main() {
     ///     let credentials = Credentials::new("username", "password");
-    ///     let client = Api::new_login("url", credentials)
+    ///     let client = Api::new_login("http://127.0.0.1/", credentials)
     ///         .await
     ///         .unwrap();
     ///
@@ -320,7 +316,7 @@ impl super::Api {
     /// #[tokio::main]
     /// async fn main() {
     ///     let credentials = Credentials::new("username", "password");
-    ///     let client = Api::new_login("url", credentials)
+    ///     let client = Api::new_login("http://127.0.0.1/", credentials)
     ///         .await
     ///         .unwrap();
     ///
@@ -361,7 +357,7 @@ impl super::Api {
     /// #[tokio::main]
     /// async fn main() {
     ///     let credentials = Credentials::new("username", "password");
-    ///     let client = Api::new_login("url", credentials)
+    ///     let client = Api::new_login("http://127.0.0.1/", credentials)
     ///         .await
     ///         .unwrap();
     ///
@@ -400,7 +396,7 @@ impl super::Api {
     /// #[tokio::main]
     /// async fn main() {
     ///     let credentials = Credentials::new("username", "password");
-    ///     let client = Api::new_login("url", credentials)
+    ///     let client = Api::new_login("http://127.0.0.1/", credentials)
     ///         .await
     ///         .unwrap();
     ///
@@ -434,7 +430,7 @@ impl super::Api {
     /// #[tokio::main]
     /// async fn main() {
     ///     let credentials = Credentials::new("username", "password");
-    ///     let client = Api::new_login("url", credentials)
+    ///     let client = Api::new_login("http://127.0.0.1/", credentials)
     ///         .await
     ///         .unwrap();
     ///
@@ -458,7 +454,7 @@ impl super::Api {
         Ok(rules)
     }
 
-    /// Get all RSS rules articles
+    /// Get all articles matching the given rule.
     ///
     /// [official documentation](https://github.com/qbittorrent/qBittorrent/wiki/WebUI-API-(qBittorrent-5.0)#get-all-articles-matching-a-rule)
     ///
@@ -473,7 +469,7 @@ impl super::Api {
     /// #[tokio::main]
     /// async fn main() {
     ///     let credentials = Credentials::new("username", "password");
-    ///     let client = Api::new_login("url", credentials)
+    ///     let client = Api::new_login("http://127.0.0.1/", credentials)
     ///         .await
     ///         .unwrap();
     ///

--- a/src/client/search.rs
+++ b/src/client/search.rs
@@ -25,7 +25,7 @@ impl super::Api {
     /// #[tokio::main]
     /// async fn main() {
     ///     let credentials = Credentials::new("username", "password");
-    ///     let client = Api::new_login("url", credentials)
+    ///     let client = Api::new_login("http://127.0.0.1/", credentials)
     ///         .await
     ///         .unwrap();
     ///
@@ -78,7 +78,7 @@ impl super::Api {
     /// #[tokio::main]
     /// async fn main() {
     ///     let credentials = Credentials::new("username", "password");
-    ///     let client = Api::new_login("url", credentials)
+    ///     let client = Api::new_login("http://127.0.0.1/", credentials)
     ///         .await
     ///         .unwrap();
     ///
@@ -116,7 +116,7 @@ impl super::Api {
     /// #[tokio::main]
     /// async fn main() {
     ///     let credentials = Credentials::new("username", "password");
-    ///     let client = Api::new_login("url", credentials)
+    ///     let client = Api::new_login("http://127.0.0.1/", credentials)
     ///         .await
     ///         .unwrap();
     ///
@@ -168,7 +168,7 @@ impl super::Api {
     /// #[tokio::main]
     /// async fn main() {
     ///     let credentials = Credentials::new("username", "password");
-    ///     let client = Api::new_login("url", credentials)
+    ///     let client = Api::new_login("http://127.0.0.1/", credentials)
     ///         .await
     ///         .unwrap();
     ///
@@ -221,7 +221,7 @@ impl super::Api {
     /// #[tokio::main]
     /// async fn main() {
     ///     let credentials = Credentials::new("username", "password");
-    ///     let client = Api::new_login("url", credentials)
+    ///     let client = Api::new_login("http://127.0.0.1/", credentials)
     ///         .await
     ///         .unwrap();
     ///
@@ -255,7 +255,7 @@ impl super::Api {
     /// #[tokio::main]
     /// async fn main() {
     ///     let credentials = Credentials::new("username", "password");
-    ///     let client = Api::new_login("url", credentials)
+    ///     let client = Api::new_login("http://127.0.0.1/", credentials)
     ///         .await
     ///         .unwrap();
     ///
@@ -296,7 +296,7 @@ impl super::Api {
     /// #[tokio::main]
     /// async fn main() {
     ///     let credentials = Credentials::new("username", "password");
-    ///     let client = Api::new_login("url", credentials)
+    ///     let client = Api::new_login("http://127.0.0.1/", credentials)
     ///         .await
     ///         .unwrap();
     ///
@@ -333,7 +333,7 @@ impl super::Api {
     /// #[tokio::main]
     /// async fn main() {
     ///     let credentials = Credentials::new("username", "password");
-    ///     let client = Api::new_login("url", credentials)
+    ///     let client = Api::new_login("http://127.0.0.1/", credentials)
     ///         .await
     ///         .unwrap();
     ///
@@ -370,7 +370,7 @@ impl super::Api {
     /// #[tokio::main]
     /// async fn main() {
     ///     let credentials = Credentials::new("username", "password");
-    ///     let client = Api::new_login("url", credentials)
+    ///     let client = Api::new_login("http://127.0.0.1/", credentials)
     ///         .await
     ///         .unwrap();
     ///
@@ -406,7 +406,7 @@ impl super::Api {
     /// #[tokio::main]
     /// async fn main() {
     ///     let credentials = Credentials::new("username", "password");
-    ///     let client = Api::new_login("url", credentials)
+    ///     let client = Api::new_login("http://127.0.0.1/", credentials)
     ///         .await
     ///         .unwrap();
     ///

--- a/src/client/search.rs
+++ b/src/client/search.rs
@@ -82,7 +82,10 @@ impl super::Api {
     ///         .await
     ///         .unwrap();
     ///
-    ///     let result = client.search_stop(1337).await;
+    ///     let id = client.search_start("Ubuntu 18.04", "legittorrents", "all")
+    ///         .await
+    ///         .unwrap();
+    ///     let result = client.search_stop(id).await;
     ///
     ///     assert!(result.is_ok());
     /// }
@@ -120,7 +123,10 @@ impl super::Api {
     ///         .await
     ///         .unwrap();
     ///
-    ///     let status = client.search_status(Some(1337))
+    ///     let id = client.search_start("Ubuntu 18.04", "legittorrents", "all")
+    ///         .await
+    ///         .unwrap();
+    ///     let status = client.search_status(Some(id))
     ///         .await
     ///         .unwrap();
     ///
@@ -148,9 +154,7 @@ impl super::Api {
         Ok(searches)
     }
 
-    /// Get search results
-    ///
-    /// This function retrieves search results for a given search job.
+    /// Retrieves search results for a given search job.
     ///
     /// [official documentation](https://github.com/qbittorrent/qBittorrent/wiki/WebUI-API-(qBittorrent-5.0)#get-search-results)
     ///
@@ -172,7 +176,10 @@ impl super::Api {
     ///         .await
     ///         .unwrap();
     ///
-    ///     let searches = client.search_results(1337, 10, None)
+    ///     let id = client.search_start("Ubuntu 18.04", "legittorrents", "all")
+    ///         .await
+    ///         .unwrap();
+    ///     let searches = client.search_results(id, 10, None)
     ///         .await
     ///         .unwrap();
     ///
@@ -225,7 +232,10 @@ impl super::Api {
     ///         .await
     ///         .unwrap();
     ///
-    ///     let result = client.search_delete(1337).await;
+    ///     let id = client.search_start("Ubuntu 18.04", "legittorrents", "all")
+    ///         .await
+    ///         .unwrap();
+    ///     let result = client.search_delete(id).await;
     ///
     ///     assert!(result.is_ok());
     /// }
@@ -281,7 +291,7 @@ impl super::Api {
         Ok(plugins)
     }
 
-    /// Install search plugin
+    /// Install search plugin/s
     ///
     /// [official documentation](https://github.com/qbittorrent/qBittorrent/wiki/WebUI-API-(qBittorrent-5.0)#install-search-plugin)
     ///
@@ -318,7 +328,7 @@ impl super::Api {
         Ok(())
     }
 
-    /// Uninstall search plugin
+    /// Uninstall search plugin/s
     ///
     /// [official documentation](https://github.com/qbittorrent/qBittorrent/wiki/WebUI-API-(qBittorrent-5.0)#uninstall-search-plugin)
     ///
@@ -337,6 +347,7 @@ impl super::Api {
     ///         .await
     ///         .unwrap();
     ///
+    ///     client.search_install_plugin(vec!["plugin"]).await.unwrap();
     ///     let result = client.search_uninstall_plugin(vec!["plugin"]).await;
     ///
     ///     assert!(result.is_ok());
@@ -355,7 +366,7 @@ impl super::Api {
         Ok(())
     }
 
-    /// Enable search plugin
+    /// Enable search plugin/s
     ///
     /// [official documentation](https://github.com/qbittorrent/qBittorrent/wiki/WebUI-API-(qBittorrent-5.0)#enable-search-plugin)
     ///
@@ -374,6 +385,7 @@ impl super::Api {
     ///         .await
     ///         .unwrap();
     ///
+    ///     client.search_install_plugin(vec!["plugin"]).await.unwrap();
     ///     let result = client.search_enable_plugin(vec!["plugin"], true).await;
     ///
     ///     assert!(result.is_ok());
@@ -394,7 +406,7 @@ impl super::Api {
         Ok(())
     }
 
-    /// Update search plugins
+    /// Update all search plugins currently installed.
     ///
     /// [official documentation](https://github.com/qbittorrent/qBittorrent/wiki/WebUI-API-(qBittorrent-5.0)#update-search-plugins)
     ///
@@ -410,6 +422,7 @@ impl super::Api {
     ///         .await
     ///         .unwrap();
     ///
+    ///     client.search_install_plugin(vec!["plugin"]).await.unwrap();
     ///     let result = client.search_update_plugin().await;
     ///
     ///     assert!(result.is_ok());

--- a/src/client/sync.rs
+++ b/src/client/sync.rs
@@ -23,7 +23,7 @@ impl super::Api {
     /// #[tokio::main]
     /// async fn main() {
     ///     let credentials = Credentials::new("username", "password");
-    ///     let client = Api::new_login("url", credentials)
+    ///     let client = Api::new_login("http://127.0.0.1/", credentials)
     ///         .await
     ///         .unwrap();
     ///
@@ -71,7 +71,7 @@ impl super::Api {
     /// #[tokio::main]
     /// async fn main() {
     ///     let credentials = Credentials::new("username", "password");
-    ///     let client = Api::new_login("url", credentials)
+    ///     let client = Api::new_login("http://127.0.0.1/", credentials)
     ///         .await
     ///         .unwrap();
     ///

--- a/src/client/sync.rs
+++ b/src/client/sync.rs
@@ -53,7 +53,7 @@ impl super::Api {
 
     /// Get torrent peers data
     ///
-    /// Fetches main data changes since the last request. If the given `rid` is different from the one of last server reply,
+    /// Fetches peer data changes since the last request. If the given `rid` is different from the one of last server reply,
     /// `full_update` will be `true`
     ///
     /// [official documentation](https://github.com/qbittorrent/qBittorrent/wiki/WebUI-API-(qBittorrent-5.0)#get-torrent-peers-data)

--- a/src/client/torrent.rs
+++ b/src/client/torrent.rs
@@ -561,7 +561,7 @@ impl super::Api {
     ///
     /// ```no_run
     /// use qbit::{Api, Credentials};
-    /// use qbit::parameters::AddTorrent;
+    /// use qbit::parameters::{AddTorrentBuilder, AddTorrentType};
     ///
     /// #[tokio::main]
     /// async fn main() {

--- a/src/client/torrent.rs
+++ b/src/client/torrent.rs
@@ -124,9 +124,7 @@ impl super::Api {
         Ok(torrent)
     }
 
-    /// Get torrent trackers information
-    ///
-    /// Gets a information of all trackers for the torrent.
+    /// Gets information of all trackers for the torrent.
     ///
     /// [official documentation](https://github.com/qbittorrent/qBittorrent/wiki/WebUI-API-(qBittorrent-5.0)#get-torrent-trackers)
     ///
@@ -169,9 +167,7 @@ impl super::Api {
         Ok(trackers)
     }
 
-    /// Get torrent web seeds
-    ///
-    /// Gets a list of direct downloads for files.
+    /// Get a list of torrent web seeds
     ///
     /// [official documentation](https://github.com/qbittorrent/qBittorrent/wiki/WebUI-API-(qBittorrent-5.0)#get-torrent-web-seeds)
     ///
@@ -214,9 +210,7 @@ impl super::Api {
         Ok(webseeds)
     }
 
-    /// Get torrent contents
-    ///
-    /// Makes a list of all files from the torrent.
+    /// Gets a list of all files in the torrent.
     ///
     /// [official documentation](https://github.com/qbittorrent/qBittorrent/wiki/WebUI-API-(qBittorrent-5.0)#get-torrent-contents)
     ///
@@ -250,8 +244,7 @@ impl super::Api {
         hash: &str,
         indexes: Option<Vec<i64>>,
     ) -> Result<Vec<TorrentContent>, Error> {
-        let mut query = vec![];
-        query.push(("hash", hash.to_string()));
+        let mut query = vec![("hash", hash.to_string())];
         if let Some(indexes) = indexes {
             query.push((
                 "filter",
@@ -276,9 +269,7 @@ impl super::Api {
         Ok(webseeds)
     }
 
-    /// Get torrent pieces' states
-    ///
-    /// Status of every piece of the torrent
+    /// Gets the status of every piece in the torrent
     ///
     /// [official documentation](https://github.com/qbittorrent/qBittorrent/wiki/WebUI-API-(qBittorrent-5.0)#get-torrent-pieces-states)
     ///
@@ -321,9 +312,7 @@ impl super::Api {
         Ok(pieces)
     }
 
-    /// Get torrent pieces' hashes
-    ///
-    /// Hash of every piece of the torrent.
+    /// Gets the hash of every piece in the torrent.
     ///
     /// [official documentation](https://github.com/qbittorrent/qBittorrent/wiki/WebUI-API-(qBittorrent-5.0)#get-torrent-pieces-hashes)
     ///
@@ -443,9 +432,6 @@ impl super::Api {
     }
 
     /// Delete torrents
-    ///
-    /// Deletes a list of torrents. By default, it will only remove the torrent
-    /// from Qbittorrent, but it can be set to delete the downloaded data as well.
     ///
     /// [official documentation](https://github.com/qbittorrent/qBittorrent/wiki/WebUI-API-(qBittorrent-5.0)#delete-torrents)
     ///
@@ -584,7 +570,10 @@ impl super::Api {
     ///         .await
     ///         .unwrap();
     ///
-    ///     let params = AddTorrent::default();
+    ///     let params = AddTorrentBuilder::default()
+    ///         .torrents(AddTorrentType::Links(vec![String::from("magnet://{magnet-url}")]))
+    ///         .build()
+    ///         .unwrap();
     ///     let result = client.add_torrent(params).await;
     ///
     ///     assert!(result.is_ok());
@@ -706,8 +695,6 @@ impl super::Api {
         Ok(())
     }
 
-    /// Edit trackers
-    ///
     /// Change a tracker url on a torrent.
     ///
     /// [official documentation](https://github.com/qbittorrent/qBittorrent/wiki/WebUI-API-(qBittorrent-5.0)#edit-trackers)
@@ -924,7 +911,7 @@ impl super::Api {
         Ok(())
     }
 
-    /// Maximal torrent priority
+    /// set torrent priority to Maximal
     ///
     /// [official documentation](https://github.com/qbittorrent/qBittorrent/wiki/WebUI-API-(qBittorrent-5.0)#maximal-torrent-priority)
     ///
@@ -963,7 +950,7 @@ impl super::Api {
         Ok(())
     }
 
-    /// Minimal torrent priority
+    /// Set torrent priority to Minimal
     ///
     /// [official documentation](https://github.com/qbittorrent/qBittorrent/wiki/WebUI-API-(qBittorrent-5.0)#minimal-torrent-priority)
     ///
@@ -1475,6 +1462,8 @@ impl super::Api {
     }
 
     /// Add new category
+    ///
+    /// If subcategories are enabled, sub categories can be created by doing `parent/child`. Internally, they are still treated as a separate unique category.
     ///
     /// [official documentation](https://github.com/qbittorrent/qBittorrent/wiki/WebUI-API-(qBittorrent-5.0)#add-new-category)
     ///

--- a/src/client/torrent.rs
+++ b/src/client/torrent.rs
@@ -30,7 +30,7 @@ impl super::Api {
     /// #[tokio::main]
     /// async fn main() {
     ///     let credentials = Credentials::new("username", "password");
-    ///     let client = Api::new_login("url", credentials)
+    ///     let client = Api::new_login("http://127.0.0.1/", credentials)
     ///         .await
     ///         .unwrap();
     ///
@@ -99,7 +99,7 @@ impl super::Api {
     /// #[tokio::main]
     /// async fn main() {
     ///     let credentials = Credentials::new("username", "password");
-    ///     let client = Api::new_login("url", credentials)
+    ///     let client = Api::new_login("http://127.0.0.1/", credentials)
     ///         .await
     ///         .unwrap();
     ///
@@ -142,7 +142,7 @@ impl super::Api {
     /// #[tokio::main]
     /// async fn main() {
     ///     let credentials = Credentials::new("username", "password");
-    ///     let client = Api::new_login("url", credentials)
+    ///     let client = Api::new_login("http://127.0.0.1/", credentials)
     ///         .await
     ///         .unwrap();
     ///
@@ -187,7 +187,7 @@ impl super::Api {
     /// #[tokio::main]
     /// async fn main() {
     ///     let credentials = Credentials::new("username", "password");
-    ///     let client = Api::new_login("url", credentials)
+    ///     let client = Api::new_login("http://127.0.0.1/", credentials)
     ///         .await
     ///         .unwrap();
     ///
@@ -234,7 +234,7 @@ impl super::Api {
     /// #[tokio::main]
     /// async fn main() {
     ///     let credentials = Credentials::new("username", "password");
-    ///     let client = Api::new_login("url", credentials)
+    ///     let client = Api::new_login("http://127.0.0.1/", credentials)
     ///         .await
     ///         .unwrap();
     ///
@@ -294,7 +294,7 @@ impl super::Api {
     /// #[tokio::main]
     /// async fn main() {
     ///     let credentials = Credentials::new("username", "password");
-    ///     let client = Api::new_login("url", credentials)
+    ///     let client = Api::new_login("http://127.0.0.1/", credentials)
     ///         .await
     ///         .unwrap();
     ///
@@ -339,7 +339,7 @@ impl super::Api {
     /// #[tokio::main]
     /// async fn main() {
     ///     let credentials = Credentials::new("username", "password");
-    ///     let client = Api::new_login("url", credentials)
+    ///     let client = Api::new_login("http://127.0.0.1/", credentials)
     ///         .await
     ///         .unwrap();
     ///
@@ -382,7 +382,7 @@ impl super::Api {
     /// #[tokio::main]
     /// async fn main() {
     ///     let credentials = Credentials::new("username", "password");
-    ///     let client = Api::new_login("url", credentials)
+    ///     let client = Api::new_login("http://127.0.0.1/", credentials)
     ///         .await
     ///         .unwrap();
     ///
@@ -420,7 +420,7 @@ impl super::Api {
     /// #[tokio::main]
     /// async fn main() {
     ///     let credentials = Credentials::new("username", "password");
-    ///     let client = Api::new_login("url", credentials)
+    ///     let client = Api::new_login("http://127.0.0.1/", credentials)
     ///         .await
     ///         .unwrap();
     ///
@@ -463,7 +463,7 @@ impl super::Api {
     /// #[tokio::main]
     /// async fn main() {
     ///     let credentials = Credentials::new("username", "password");
-    ///     let client = Api::new_login("url", credentials)
+    ///     let client = Api::new_login("http://127.0.0.1/", credentials)
     ///         .await
     ///         .unwrap();
     ///
@@ -503,7 +503,7 @@ impl super::Api {
     /// #[tokio::main]
     /// async fn main() {
     ///     let credentials = Credentials::new("username", "password");
-    ///     let client = Api::new_login("url", credentials)
+    ///     let client = Api::new_login("http://127.0.0.1/", credentials)
     ///         .await
     ///         .unwrap();
     ///
@@ -541,7 +541,7 @@ impl super::Api {
     /// #[tokio::main]
     /// async fn main() {
     ///     let credentials = Credentials::new("username", "password");
-    ///     let client = Api::new_login("url", credentials)
+    ///     let client = Api::new_login("http://127.0.0.1/", credentials)
     ///         .await
     ///         .unwrap();
     ///
@@ -580,7 +580,7 @@ impl super::Api {
     /// #[tokio::main]
     /// async fn main() {
     ///     let credentials = Credentials::new("username", "password");
-    ///     let client = Api::new_login("url", credentials)
+    ///     let client = Api::new_login("http://127.0.0.1/", credentials)
     ///         .await
     ///         .unwrap();
     ///
@@ -681,7 +681,7 @@ impl super::Api {
     /// #[tokio::main]
     /// async fn main() {
     ///     let credentials = Credentials::new("username", "password");
-    ///     let client = Api::new_login("url", credentials)
+    ///     let client = Api::new_login("http://127.0.0.1/", credentials)
     ///         .await
     ///         .unwrap();
     ///
@@ -726,7 +726,7 @@ impl super::Api {
     /// #[tokio::main]
     /// async fn main() {
     ///     let credentials = Credentials::new("username", "password");
-    ///     let client = Api::new_login("url", credentials)
+    ///     let client = Api::new_login("http://127.0.0.1/", credentials)
     ///         .await
     ///         .unwrap();
     ///
@@ -774,7 +774,7 @@ impl super::Api {
     /// #[tokio::main]
     /// async fn main() {
     ///     let credentials = Credentials::new("username", "password");
-    ///     let client = Api::new_login("url", credentials)
+    ///     let client = Api::new_login("http://127.0.0.1/", credentials)
     ///         .await
     ///         .unwrap();
     ///
@@ -820,7 +820,7 @@ impl super::Api {
     /// #[tokio::main]
     /// async fn main() {
     ///     let credentials = Credentials::new("username", "password");
-    ///     let client = Api::new_login("url", credentials)
+    ///     let client = Api::new_login("http://127.0.0.1/", credentials)
     ///         .await
     ///         .unwrap();
     ///
@@ -863,7 +863,7 @@ impl super::Api {
     /// #[tokio::main]
     /// async fn main() {
     ///     let credentials = Credentials::new("username", "password");
-    ///     let client = Api::new_login("url", credentials)
+    ///     let client = Api::new_login("http://127.0.0.1/", credentials)
     ///         .await
     ///         .unwrap();
     ///
@@ -902,7 +902,7 @@ impl super::Api {
     /// #[tokio::main]
     /// async fn main() {
     ///     let credentials = Credentials::new("username", "password");
-    ///     let client = Api::new_login("url", credentials)
+    ///     let client = Api::new_login("http://127.0.0.1/", credentials)
     ///         .await
     ///         .unwrap();
     ///
@@ -941,7 +941,7 @@ impl super::Api {
     /// #[tokio::main]
     /// async fn main() {
     ///     let credentials = Credentials::new("username", "password");
-    ///     let client = Api::new_login("url", credentials)
+    ///     let client = Api::new_login("http://127.0.0.1/", credentials)
     ///         .await
     ///         .unwrap();
     ///
@@ -980,7 +980,7 @@ impl super::Api {
     /// #[tokio::main]
     /// async fn main() {
     ///     let credentials = Credentials::new("username", "password");
-    ///     let client = Api::new_login("url", credentials)
+    ///     let client = Api::new_login("http://127.0.0.1/", credentials)
     ///         .await
     ///         .unwrap();
     ///
@@ -1021,7 +1021,7 @@ impl super::Api {
     /// #[tokio::main]
     /// async fn main() {
     ///     let credentials = Credentials::new("username", "password");
-    ///     let client = Api::new_login("url", credentials)
+    ///     let client = Api::new_login("http://127.0.0.1/", credentials)
     ///         .await
     ///         .unwrap();
     ///
@@ -1075,7 +1075,7 @@ impl super::Api {
     /// #[tokio::main]
     /// async fn main() {
     ///     let credentials = Credentials::new("username", "password");
-    ///     let client = Api::new_login("url", credentials)
+    ///     let client = Api::new_login("http://127.0.0.1/", credentials)
     ///         .await
     ///         .unwrap();
     ///
@@ -1123,7 +1123,7 @@ impl super::Api {
     /// #[tokio::main]
     /// async fn main() {
     ///     let credentials = Credentials::new("username", "password");
-    ///     let client = Api::new_login("url", credentials)
+    ///     let client = Api::new_login("http://127.0.0.1/", credentials)
     ///         .await
     ///         .unwrap();
     ///
@@ -1177,7 +1177,7 @@ impl super::Api {
     /// #[tokio::main]
     /// async fn main() {
     ///     let credentials = Credentials::new("username", "password");
-    ///     let client = Api::new_login("url", credentials)
+    ///     let client = Api::new_login("http://127.0.0.1/", credentials)
     ///         .await
     ///         .unwrap();
     ///
@@ -1229,7 +1229,7 @@ impl super::Api {
     /// #[tokio::main]
     /// async fn main() {
     ///     let credentials = Credentials::new("username", "password");
-    ///     let client = Api::new_login("url", credentials)
+    ///     let client = Api::new_login("http://127.0.0.1/", credentials)
     ///         .await
     ///         .unwrap();
     ///
@@ -1277,7 +1277,7 @@ impl super::Api {
     /// #[tokio::main]
     /// async fn main() {
     ///     let credentials = Credentials::new("username", "password");
-    ///     let client = Api::new_login("url", credentials)
+    ///     let client = Api::new_login("http://127.0.0.1/", credentials)
     ///         .await
     ///         .unwrap();
     ///
@@ -1323,7 +1323,7 @@ impl super::Api {
     /// #[tokio::main]
     /// async fn main() {
     ///     let credentials = Credentials::new("username", "password");
-    ///     let client = Api::new_login("url", credentials)
+    ///     let client = Api::new_login("http://127.0.0.1/", credentials)
     ///         .await
     ///         .unwrap();
     ///
@@ -1368,7 +1368,7 @@ impl super::Api {
     /// #[tokio::main]
     /// async fn main() {
     ///     let credentials = Credentials::new("username", "password");
-    ///     let client = Api::new_login("url", credentials)
+    ///     let client = Api::new_login("http://127.0.0.1/", credentials)
     ///         .await
     ///         .unwrap();
     ///
@@ -1410,7 +1410,7 @@ impl super::Api {
     /// #[tokio::main]
     /// async fn main() {
     ///     let credentials = Credentials::new("username", "password");
-    ///     let client = Api::new_login("url", credentials)
+    ///     let client = Api::new_login("http://127.0.0.1/", credentials)
     ///         .await
     ///         .unwrap();
     ///
@@ -1450,7 +1450,7 @@ impl super::Api {
     /// #[tokio::main]
     /// async fn main() {
     ///     let credentials = Credentials::new("username", "password");
-    ///     let client = Api::new_login("url", credentials)
+    ///     let client = Api::new_login("http://127.0.0.1/", credentials)
     ///         .await
     ///         .unwrap();
     ///
@@ -1491,7 +1491,7 @@ impl super::Api {
     /// #[tokio::main]
     /// async fn main() {
     ///     let credentials = Credentials::new("username", "password");
-    ///     let client = Api::new_login("url", credentials)
+    ///     let client = Api::new_login("http://127.0.0.1/", credentials)
     ///         .await
     ///         .unwrap();
     ///
@@ -1532,7 +1532,7 @@ impl super::Api {
     /// #[tokio::main]
     /// async fn main() {
     ///     let credentials = Credentials::new("username", "password");
-    ///     let client = Api::new_login("url", credentials)
+    ///     let client = Api::new_login("http://127.0.0.1/", credentials)
     ///         .await
     ///         .unwrap();
     ///
@@ -1572,7 +1572,7 @@ impl super::Api {
     /// #[tokio::main]
     /// async fn main() {
     ///     let credentials = Credentials::new("username", "password");
-    ///     let client = Api::new_login("url", credentials)
+    ///     let client = Api::new_login("http://127.0.0.1/", credentials)
     ///         .await
     ///         .unwrap();
     ///
@@ -1613,7 +1613,7 @@ impl super::Api {
     /// #[tokio::main]
     /// async fn main() {
     ///     let credentials = Credentials::new("username", "password");
-    ///     let client = Api::new_login("url", credentials)
+    ///     let client = Api::new_login("http://127.0.0.1/", credentials)
     ///         .await
     ///         .unwrap();
     ///
@@ -1656,7 +1656,7 @@ impl super::Api {
     /// #[tokio::main]
     /// async fn main() {
     ///     let credentials = Credentials::new("username", "password");
-    ///     let client = Api::new_login("url", credentials)
+    ///     let client = Api::new_login("http://127.0.0.1/", credentials)
     ///         .await
     ///         .unwrap();
     ///
@@ -1697,7 +1697,7 @@ impl super::Api {
     /// #[tokio::main]
     /// async fn main() {
     ///     let credentials = Credentials::new("username", "password");
-    ///     let client = Api::new_login("url", credentials)
+    ///     let client = Api::new_login("http://127.0.0.1/", credentials)
     ///         .await
     ///         .unwrap();
     ///
@@ -1737,7 +1737,7 @@ impl super::Api {
     /// #[tokio::main]
     /// async fn main() {
     ///     let credentials = Credentials::new("username", "password");
-    ///     let client = Api::new_login("url", credentials)
+    ///     let client = Api::new_login("http://127.0.0.1/", credentials)
     ///         .await
     ///         .unwrap();
     ///
@@ -1776,7 +1776,7 @@ impl super::Api {
     /// #[tokio::main]
     /// async fn main() {
     ///     let credentials = Credentials::new("username", "password");
-    ///     let client = Api::new_login("url", credentials)
+    ///     let client = Api::new_login("http://127.0.0.1/", credentials)
     ///         .await
     ///         .unwrap();
     ///
@@ -1817,7 +1817,7 @@ impl super::Api {
     /// #[tokio::main]
     /// async fn main() {
     ///     let credentials = Credentials::new("username", "password");
-    ///     let client = Api::new_login("url", credentials)
+    ///     let client = Api::new_login("http://127.0.0.1/", credentials)
     ///         .await
     ///         .unwrap();
     ///
@@ -1862,7 +1862,7 @@ impl super::Api {
     /// #[tokio::main]
     /// async fn main() {
     ///     let credentials = Credentials::new("username", "password");
-    ///     let client = Api::new_login("url", credentials)
+    ///     let client = Api::new_login("http://127.0.0.1/", credentials)
     ///         .await
     ///         .unwrap();
     ///
@@ -1901,7 +1901,7 @@ impl super::Api {
     /// #[tokio::main]
     /// async fn main() {
     ///     let credentials = Credentials::new("username", "password");
-    ///     let client = Api::new_login("url", credentials)
+    ///     let client = Api::new_login("http://127.0.0.1/", credentials)
     ///         .await
     ///         .unwrap();
     ///
@@ -1941,7 +1941,7 @@ impl super::Api {
     /// #[tokio::main]
     /// async fn main() {
     ///     let credentials = Credentials::new("username", "password");
-    ///     let client = Api::new_login("url", credentials)
+    ///     let client = Api::new_login("http://127.0.0.1/", credentials)
     ///         .await
     ///         .unwrap();
     ///
@@ -1987,7 +1987,7 @@ impl super::Api {
     /// #[tokio::main]
     /// async fn main() {
     ///     let credentials = Credentials::new("username", "password");
-    ///     let client = Api::new_login("url", credentials)
+    ///     let client = Api::new_login("http://127.0.0.1/", credentials)
     ///         .await
     ///         .unwrap();
     ///
@@ -2033,7 +2033,7 @@ impl super::Api {
     /// #[tokio::main]
     /// async fn main() {
     ///     let credentials = Credentials::new("username", "password");
-    ///     let client = Api::new_login("url", credentials)
+    ///     let client = Api::new_login("http://127.0.0.1/", credentials)
     ///         .await
     ///         .unwrap();
     ///
@@ -2081,7 +2081,7 @@ impl super::Api {
     /// #[tokio::main]
     /// async fn main() {
     ///     let credentials = Credentials::new("username", "password");
-    ///     let client = Api::new_login("url", credentials)
+    ///     let client = Api::new_login("http://127.0.0.1/", credentials)
     ///         .await
     ///         .unwrap();
     ///

--- a/src/client/transfer.rs
+++ b/src/client/transfer.rs
@@ -17,7 +17,7 @@ impl super::Api {
     /// #[tokio::main]
     /// async fn main() {
     ///     let credentials = Credentials::new("username", "password");
-    ///     let client = Api::new_login("url", credentials)
+    ///     let client = Api::new_login("http://127.0.0.1/", credentials)
     ///         .await
     ///         .unwrap();
     ///
@@ -53,7 +53,7 @@ impl super::Api {
     /// #[tokio::main]
     /// async fn main() {
     ///     let credentials = Credentials::new("username", "password");
-    ///     let client = Api::new_login("url", credentials)
+    ///     let client = Api::new_login("http://127.0.0.1/", credentials)
     ///         .await
     ///         .unwrap();
     ///
@@ -87,7 +87,7 @@ impl super::Api {
     /// #[tokio::main]
     /// async fn main() {
     ///     let credentials = Credentials::new("username", "password");
-    ///     let client = Api::new_login("url", credentials)
+    ///     let client = Api::new_login("http://127.0.0.1/", credentials)
     ///         .await
     ///         .unwrap();
     ///
@@ -118,7 +118,7 @@ impl super::Api {
     /// #[tokio::main]
     /// async fn main() {
     ///     let credentials = Credentials::new("username", "password");
-    ///     let client = Api::new_login("url", credentials)
+    ///     let client = Api::new_login("http://127.0.0.1/", credentials)
     ///         .await
     ///         .unwrap();
     ///
@@ -156,7 +156,7 @@ impl super::Api {
     /// #[tokio::main]
     /// async fn main() {
     ///     let credentials = Credentials::new("username", "password");
-    ///     let client = Api::new_login("url", credentials)
+    ///     let client = Api::new_login("http://127.0.0.1/", credentials)
     ///         .await
     ///         .unwrap();
     ///
@@ -190,7 +190,7 @@ impl super::Api {
     /// #[tokio::main]
     /// async fn main() {
     ///     let credentials = Credentials::new("username", "password");
-    ///     let client = Api::new_login("url", credentials)
+    ///     let client = Api::new_login("http://127.0.0.1/", credentials)
     ///         .await
     ///         .unwrap();
     ///
@@ -228,7 +228,7 @@ impl super::Api {
     /// #[tokio::main]
     /// async fn main() {
     ///     let credentials = Credentials::new("username", "password");
-    ///     let client = Api::new_login("url", credentials)
+    ///     let client = Api::new_login("http://127.0.0.1/", credentials)
     ///         .await
     ///         .unwrap();
     ///
@@ -266,7 +266,7 @@ impl super::Api {
     /// #[tokio::main]
     /// async fn main() {
     ///     let credentials = Credentials::new("username", "password");
-    ///     let client = Api::new_login("url", credentials)
+    ///     let client = Api::new_login("http://127.0.0.1/", credentials)
     ///         .await
     ///         .unwrap();
     ///

--- a/src/client/transfer.rs
+++ b/src/client/transfer.rs
@@ -41,8 +41,6 @@ impl super::Api {
 
     /// Get alternative speed limits state
     ///
-    /// The response is 1 if alternative speed limits are enabled, 0 otherwise.
-    ///
     /// [official documentation](https://github.com/qbittorrent/qBittorrent/wiki/WebUI-API-(qBittorrent-5.0)#get-alternative-speed-limits-state)
     ///
     /// # Example
@@ -256,7 +254,7 @@ impl super::Api {
     ///
     /// # Arguments
     ///
-    /// * `peers` - The peer to ban, or multiple peers. Each peer is a colon-separated `host:port`
+    /// * `peers` - The peer to ban, or multiple peers. Each peer is `host:port`
     ///
     /// # Example
     ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,16 +53,24 @@ use serde::{Deserialize, Serialize};
 /// [Commit](https://github.com/George-Miao/qbit/commit/fe1240c05b4d3feeafb327e8ba7f0eeba97735c5#diff-b1a35a68f14e696205874893c07fd24fdb88882b47c23cc0e0c80a30c7d53759R28)
 #[derive(Debug, Deserialize, Serialize, Clone, Default, PartialEq)]
 pub enum LoginState {
+    /// The user is logged in.
     LoggedIn {
+        /// Credentials used to log in.
         credentials: Credentials,
+        /// Session cookie used to log in.
         cookie_sid: String,
     },
+    /// The user is not logged in but we have credenitals.
     NotLoggedIn {
+        /// Credentials used to log in
         credentials: Credentials,
     },
-    CookieProvidet {
+    /// The user is not logged in but we have the cookie to log them in.
+    CookieProvided {
+        /// Session cookie used to log in.
         cookie_sid: String,
     },
+    /// We don't know if the user is logged in or not.
     #[default]
     Unknown,
 }
@@ -72,7 +80,7 @@ impl LoginState {
         match self {
             Self::LoggedIn { cookie_sid, .. } => Some(cookie_sid.to_string()),
             Self::NotLoggedIn { .. } => None,
-            Self::CookieProvidet { cookie_sid } => Some(cookie_sid.to_string()),
+            Self::CookieProvided { cookie_sid } => Some(cookie_sid.to_string()),
             Self::Unknown => None,
         }
     }
@@ -81,7 +89,7 @@ impl LoginState {
         let creds = match self {
             Self::LoggedIn { credentials, .. } => Some(credentials),
             Self::NotLoggedIn { credentials } => Some(credentials),
-            Self::CookieProvidet { .. } => return None,
+            Self::CookieProvided { .. } => return None,
             Self::Unknown => return None,
         };
 
@@ -102,10 +110,10 @@ impl LoginState {
                 cookie_sid: cookie.to_string(),
                 credentials: credentials.clone(),
             },
-            Self::CookieProvidet { .. } => Self::CookieProvidet {
+            Self::CookieProvided { .. } => Self::CookieProvided {
                 cookie_sid: cookie.to_string(),
             },
-            Self::Unknown => Self::CookieProvidet {
+            Self::Unknown => Self::CookieProvided {
                 cookie_sid: cookie.to_string(),
             },
         }
@@ -120,6 +128,7 @@ pub struct Credentials {
 }
 
 impl Credentials {
+    /// Create a new set of credentials with the provided username and password
     pub fn new(username: impl Into<String>, password: impl Into<String>) -> Self {
         Self {
             username: username.into(),

--- a/src/models/creator.rs
+++ b/src/models/creator.rs
@@ -54,9 +54,13 @@ pub struct TorrentCreator {
     /// Note: If piece size is too big this can cause the torrent to fail to be added.
     #[builder(setter(into, strip_option), default)]
     pub piece_size: Option<TorrentPieceSize>,
+    /// Should optimize alignment
     #[builder(default = Some(false))]
     pub optimize_alignment: Option<bool>,
-    /// -1 = disable
+    /// Size limit for padding files
+    ///
+    /// Used with other clients that are not `LibTorrent2`, shouldn't need to be
+    /// changed unless the client is different.
     #[builder(setter(into, strip_option), default = Some(-1))]
     pub padded_file_size_limit: Option<i64>,
     /// Is the torrent private or not? (Won't distrubte on DHT network if private.)
@@ -74,6 +78,9 @@ pub struct TorrentCreator {
     /// List of url seeds
     #[builder(setter(into, strip_option), default)]
     pub url_seeds: Option<Vec<String>>,
+    /// Source metadata field.
+    ///
+    /// Used for cross-seeding by some private trackers
     #[builder(setter(into, strip_option), default)]
     pub source: Option<String>,
     /// A comment to attach to the torrent.
@@ -81,6 +88,9 @@ pub struct TorrentCreator {
     pub comment: Option<String>,
 }
 
+/// A wrapper of a string, used to store the task_id just created.
+///
+/// Usages should be like a normal string.
 #[derive(Debug, Deserialize, Serialize, Clone)]
 pub struct TorrentCreatorTask {
     /// The task id related to the torrent just created
@@ -206,9 +216,13 @@ impl TorrentPieceSize {
 /// The current status of the task
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
 pub enum TaskStatus {
+    /// The task failed to complete, see `error_message` of `TorrentCreatorTaskStatus` for the reason why
     Failed,
+    /// The task is in the queue waiting to be processed
     Queued,
+    /// The task is current being processed
     Running,
+    /// The task has finished processing successfully.
     Finished,
 }
 

--- a/src/models/log.rs
+++ b/src/models/log.rs
@@ -25,10 +25,14 @@ pub struct LogItem {
 #[derive(Debug, Deserialize_repr, Serialize_repr, Clone, Default, PartialEq)]
 #[repr(u8)]
 pub enum LogType {
+    /// Include normal messages
     #[default]
     Normal = 1,
+    /// Include Information messages
     Info = 2,
+    /// Include Warning messages
     Warning = 4,
+    /// Include Critical messages
     Critical = 8,
 }
 

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -28,10 +28,13 @@ pub use transfer::*;
 /// Connection status of the Qbit application
 #[derive(Debug, Deserialize, Serialize, Clone, Default, PartialEq)]
 pub enum ConnectionStatus {
+    /// The client is connected to the other cliet / server
     #[serde(rename = "connected")]
     Connected,
+    /// The client is connected to the other cliet / server but through a firewall
     #[serde(rename = "firewalled")]
     Firewalled,
+    /// The client is not connected to the other cliet / server (or was and then disconnectede)
     #[serde(rename = "disconnected")]
     #[default]
     Disconnected,

--- a/src/models/rss.rs
+++ b/src/models/rss.rs
@@ -63,6 +63,7 @@ pub struct RssArticle {
     date: String,
 }
 
+/// Information about a specific rule to use within rss feeds.
 #[derive(Debug, Deserialize, Serialize, Clone, Default, PartialEq)]
 pub struct RssRule {
     /// Whether the rule is enabled

--- a/src/models/search.rs
+++ b/src/models/search.rs
@@ -1,5 +1,6 @@
 use serde::{Deserialize, Serialize};
 
+/// Information about a search job.
 #[derive(Debug, Deserialize, Serialize, Clone, Default, PartialEq)]
 pub struct Search {
     /// ID of the search job
@@ -10,13 +11,17 @@ pub struct Search {
     pub total: u64,
 }
 
+/// The status of the search job
 #[derive(Debug, Deserialize, Serialize, Clone, Default, PartialEq)]
 pub enum SearchStatus {
+    /// The search job active looking for results
     Running,
+    /// The search job has finished / failed / user stopped.
     #[default]
     Stopped,
 }
 
+/// Results of the provided search id.
 #[derive(Debug, Deserialize, Serialize, Clone, Default, PartialEq)]
 pub struct SearchResult {
     /// List of `SearchResultItem`.
@@ -27,6 +32,7 @@ pub struct SearchResult {
     pub total: u64,
 }
 
+/// An individual item that has been found.
 #[derive(Debug, Deserialize, Serialize, Clone, Default, PartialEq)]
 pub struct SearchResultItem {
     /// URL pointing to the torrent's description page on the source site.
@@ -52,6 +58,7 @@ pub struct SearchResultItem {
     pub site_url: String,
 }
 
+/// Information about a specific plugin used to search.
 #[derive(Debug, Deserialize, Serialize, Clone, Default, PartialEq)]
 pub struct SearchPlugin {
     /// Whether the plugin is enabled.
@@ -70,6 +77,7 @@ pub struct SearchPlugin {
     pub version: String,
 }
 
+/// Information about the category the search plugin comes under.
 #[derive(Debug, Deserialize, Serialize, Clone, Default, PartialEq)]
 pub struct SearchCategory {
     /// Identifier for the category (e.g., "all", "books", "tv").

--- a/src/models/sync.rs
+++ b/src/models/sync.rs
@@ -42,12 +42,15 @@ pub struct Category {
 }
 
 /// Server state response data object.
+///
+/// All of the values are based depending on the last time the request got sent.
 #[derive(Debug, Deserialize, Serialize, Clone, Default, PartialEq)]
 pub struct ServerState {
     /// Alltime download
     pub alltime_dl: i64,
     /// Alltime upload
     pub alltime_ul: i64,
+    /// Average time in queue in ms
     pub average_time_queue: i64,
     /// Connection status
     pub connection_status: ConnectionStatus,
@@ -62,16 +65,33 @@ pub struct ServerState {
     /// Free disk space
     pub free_space_on_disk: i64,
     /// Global ratio
-    pub global_ratio: String, // Is float in format of string
+    #[serde(
+        deserialize_with = "deserialize_string_to_f64",
+        serialize_with = "serialize_f64_to_string"
+    )]
+    pub global_ratio: f64,
     /// Last external IPv4 address
     pub last_external_address_v4: String,
     /// Last external IPv4 address
     pub last_external_address_v6: String,
     /// Queued IO jobs
     pub queued_io_jobs: i64,
+    /// Torrent queueing (application perfence setting)
     pub queueing: bool,
-    pub read_cache_hits: String,     // Is integer in format of string
-    pub read_cache_overload: String, // Is integer in format of string
+    /// How many times the read cache has been hit
+    #[serde(
+        deserialize_with = "deserialize_string_to_u64",
+        serialize_with = "serialize_u64_to_string"
+    )]
+    pub read_cache_hits: u64,
+    /// How overloaded is the read cache.
+    ///
+    /// Calculated by read queue size / peer count
+    #[serde(
+        deserialize_with = "deserialize_string_to_u64",
+        serialize_with = "serialize_u64_to_string"
+    )]
+    pub read_cache_overload: u64,
     /// Refresh Interval
     pub refresh_interval: i64,
     /// Total buffer size
@@ -80,6 +100,11 @@ pub struct ServerState {
     pub total_peer_connections: i64,
     /// Total queued size
     pub total_queued_size: i64,
+    /// How much data has been wasted in this session. (in bytes)
+    ///
+    /// Wasted data contains:
+    /// - Failed piece checks
+    /// - Duplicate Downloads
     pub total_wasted_session: i64,
     /// Upload data
     pub up_info_data: i64,
@@ -91,7 +116,44 @@ pub struct ServerState {
     pub use_alt_speed_limits: bool,
     /// Use subcategories
     pub use_subcategories: bool,
-    pub write_cache_overload: String, // Is integer in format of string
+    /// How overloaded is the read cache.
+    ///
+    /// Calculated by write queue size / peer count
+    #[serde(
+        deserialize_with = "deserialize_string_to_u64",
+        serialize_with = "serialize_u64_to_string"
+    )]
+    pub write_cache_overload: u64,
+}
+
+fn deserialize_string_to_f64<'de, D>(deserializer: D) -> Result<f64, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let s = String::deserialize(deserializer)?;
+    s.parse::<f64>().map_err(serde::de::Error::custom)
+}
+
+fn serialize_f64_to_string<S>(value: &f64, serializer: S) -> Result<S::Ok, S::Error>
+where
+    S: serde::Serializer,
+{
+    serializer.serialize_str(&value.to_string())
+}
+
+fn deserialize_string_to_u64<'de, D>(deserializer: D) -> Result<u64, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let s = String::deserialize(deserializer)?;
+    s.parse::<u64>().map_err(serde::de::Error::custom)
+}
+
+fn serialize_u64_to_string<S>(value: &u64, serializer: S) -> Result<S::Ok, S::Error>
+where
+    S: serde::Serializer,
+{
+    serializer.serialize_str(&value.to_string())
 }
 
 /// Peers response data object.
@@ -99,6 +161,7 @@ pub struct ServerState {
 pub struct PeersData {
     /// Response ID
     pub rid: i64,
+    /// Whether the response contains all the data or partial data
     pub full_update: Option<bool>,
     /// Flags
     pub show_flags: Option<bool>,
@@ -109,6 +172,8 @@ pub struct PeersData {
 }
 
 /// Peer response data object.
+///
+/// All of the values are based on the last time the request got sent.
 #[derive(Debug, Deserialize, Serialize, Clone, Default, PartialEq)]
 pub struct Peer {
     /// Client used by the peer. (μTorrent, qBittorrent, etc...)

--- a/src/models/sync.rs
+++ b/src/models/sync.rs
@@ -200,7 +200,11 @@ pub struct Peer {
     pub peer_id_client: Option<String>,
     /// Connection port
     pub port: Option<i64>,
+    /// How much has the specified peer already downloaded.
     pub progress: Option<f32>,
+    /// The ratio of the number of pieces the peer have but you don't have to the total number of pieces you don't have.
+    ///
+    /// See https://github.com/qbittorrent/qBittorrent/issues/18536 for more information.
     pub relevance: Option<f32>,
     /// Upload speed
     pub up_speed: Option<i64>,

--- a/src/models/torrent.rs
+++ b/src/models/torrent.rs
@@ -481,7 +481,7 @@ pub struct TorrentContent {
     pub progress: f64,
     /// File priority.
     pub priority: FilePriority,
-    /// True if file is seeding/complete
+    /// Is file seeding / completed.
     pub is_seed: Option<bool>,
     /// The first number is the starting piece index and the second number is the ending piece index (inclusive)
     pub piece_range: Vec<i64>,
@@ -508,8 +508,11 @@ pub enum FilePriority {
 #[derive(Debug, Deserialize_repr, Serialize_repr, Clone, Default, PartialEq)]
 #[repr(u8)]
 pub enum PiecesState {
+    /// The piece has not yet been downloaded
     #[default]
     NotDownloaded = 0,
+    /// The piece is in the progress of being downloaded
     Downloading = 1,
+    /// The piece has been downloaded.
     Downloaded = 2,
 }

--- a/src/models/torrent.rs
+++ b/src/models/torrent.rs
@@ -163,7 +163,7 @@ pub struct Torrent {
     pub total_size: i64,
     /// The first tracker with working status. Returns empty string if no tracker is working.
     pub tracker: String,
-    /// Totall count of trackers
+    /// Total count of trackers
     pub trackers_count: i64,
     /// Torrent upload speed limit (bytes/s). -1 if unlimited.
     pub up_limit: i64,

--- a/src/models/transfer.rs
+++ b/src/models/transfer.rs
@@ -18,15 +18,11 @@ pub struct TransferInfo {
     /// Download rate limit (bytes/s)
     pub dl_rate_limit: i64,
     /// Upload rate limit (bytes/s)
-    pub dht_nodes: i64,
+    pub ul_rate_limit: i64,
     /// DHT nodes connected to
+    pub dht_nodes: i64,
+    /// The connection status of qbitt.
     pub connection_status: ConnectionStatus,
-    /// True if torrent queueing is enabled
-    pub queueing: Option<bool>,
-    /// True if alternative speed limits are enabled
-    pub use_alt_speed_limits: Option<bool>,
-    /// Transfer list refresh interval (milliseconds)
-    pub refresh_interval: Option<bool>,
     /// Last external IPv4 address
     ///
     /// This field has not been documented in the API!

--- a/src/parameters.rs
+++ b/src/parameters.rs
@@ -12,16 +12,16 @@ use crate::models::ContentLayout;
 /// Torrent List/info parameter object
 #[derive(Debug, Default, Builder, Clone, Deserialize, Serialize, PartialEq)]
 pub struct TorrentListParams {
-    /// Filter torrent list by state. Allowed state filters: TorrentState
+    /// Filter torrent list by state. See FilterTorrentState for the allowed filters.
     #[builder(setter(strip_option), default)]
     pub filter: Option<FilterTorrentState>,
     /// Get torrents with the given category (empty string means "without category"; no "category" parameter means "any category"). Remember to URL-encode the category name. For example, `My category` becomes `My%20category`
     #[builder(setter(into, strip_option), default)]
     pub category: Option<String>,
-    /// Get torrents with the given tag (empty string means "without tag"; no "tag" parameter means "any tag". Remember to URL-encode the category name. For example, `My tag` becomes `My%20tag`
+    /// Get torrents with the given tag (empty string means "without tag"; no "tag" parameter means "any tag"). Remember to URL-encode the category name. For example, `My tag` becomes `My%20tag`
     #[builder(setter(into, strip_option), default)]
     pub tag: Option<String>,
-    /// Sort torrents by given key. They can be sorted using any field of the response's JSON array (which are documented below) as the sort key.
+    /// Sort torrents by given key. They can be sorted using any field of the response's JSON array (see `TorrentSort`) as the sort key.
     #[builder(setter(strip_option), default)]
     pub sort: Option<TorrentSort>,
     /// Enable reverse sorting. Defaults to `false`
@@ -33,7 +33,7 @@ pub struct TorrentListParams {
     /// Set offset (if less than 0, offset from end)
     #[builder(setter(into, strip_option), default)]
     pub offset: Option<i64>,
-    /// Filter by hashes. Can contain multiple hashes separated by `|`
+    /// Filter by hashes.
     #[builder(setter(into, strip_option), default)]
     pub hashes: Option<Vec<String>>,
 }
@@ -41,18 +41,30 @@ pub struct TorrentListParams {
 /// Possible Torrent states that can be filtered.
 #[derive(Debug, Deserialize, Serialize, Clone, Default, PartialEq)]
 pub enum FilterTorrentState {
+    /// Every filter
     #[default]
     All,
+    /// Only torrents which are downloading
     Downloading,
+    /// Only torrents which are seeding
     Seeding,
+    /// Only torrents which are completed
     Completed,
+    /// Only torrents which are stopped
     Stopped,
+    /// Only torrents which are active (downloading, seeding, metadata, etc)
     Active,
+    /// Only torrents which are inactive (stopped, stalled, errored)
     Inactive,
+    /// Only torrents which are running (same as active, or checking disk files)
     Running,
+    /// Only torrents which are stalled (no data transfer, coverse both `StalledUploading` and `StalledDownloading`)
     Stalled,
+    /// Only torrents which are stalled uploading (not seeding any data)
     StalledUploading,
+    /// Only torrents which are stalled downloading (not receiving any dataa)
     StalledDownloading,
+    /// Only torrents which are errored. (Missing files, failed to write, etc)
     Errored,
 }
 
@@ -357,6 +369,7 @@ pub enum TorrentSort {
     Progress,
     /// Torrent share ratio.
     Ratio,
+    /// Maximum share ratio limit for the torrent
     RatioLimit,
     /// Time until the next tracker reannounce
     Reannounce,
@@ -504,22 +517,17 @@ pub struct AddTorrent {
     pub first_last_piece_prio: bool,
 }
 
-impl AddTorrent {
-    pub fn new() -> Self {
-        // Although Self::default() could work here, this is done as semi boiler plate for future things if need be.
-        Self {
-            ..Default::default()
-        }
-    }
-}
-
+/// The type of torrent to add. Either `magnet` links or `.torrent` files.
 #[derive(Debug, Deserialize, Serialize, Clone, PartialEq)]
 pub enum AddTorrentType {
+    /// Magnet links to add
     Links(Vec<String>),
+    /// Files to add
     Files(Vec<TorrentFile>),
 }
 
 impl AddTorrentType {
+    /// Checks to see if we have either urls/files. (Can't add a torrent without these)
     pub fn is_empty(&self) -> bool {
         match self {
             AddTorrentType::Links(items) => items.is_empty(),
@@ -558,8 +566,11 @@ impl Default for AddTorrentType {
     }
 }
 
+/// Information about the torrent file
 #[derive(Debug, Deserialize, Serialize, Clone, Default, PartialEq)]
 pub struct TorrentFile {
+    /// Name of file
     pub filename: String,
+    /// Data stored in the file. (just fs::read would work)
     pub data: Vec<u8>,
 }


### PR DESCRIPTION
Which got knocked out in way quicker time than part 1. But i can't be bothered to merge the two parts into a big one so this is built off `master`. Merging doesn't cause any conflicts though so it's all fine.

Most of the documentation is fine, this just adds missing documentation and updates some of the examples to be a tad bit more realistic.

This also catches 1 final spelling mistake that happened due to: https://github.com/Mattress237/qbittorrent-webui-api/pull/2#issuecomment-3005580153. Although then again, why is `LoginState` public? Even the implentation it came from has it as private...

`ServerState` also gained 2/2 new serialisers/deserialisers as i see no reason why we should make it a string when we have the ability to use floats and stuff. The serialisers/deserialisers should probably be moved to the `utils` folder at some point though.

And lastly, i removed 3 pararmets from `TransferInfo`. When i go to `/transfer/info` i get this:
```jsonc
// This is with queueing and alternative rate limits enabled
{
  "connection_status": "connected",
  "dht_nodes": 128,
  "dl_info_data": 0,
  "dl_info_speed": 0,
  "dl_rate_limit": 1024,
  "last_external_address_v4": "217.155.63.51",
  "last_external_address_v6": "",
  "up_info_data": 17009975,
  "up_info_speed": 0,
  "up_rate_limit": 1024
}
```
So unless it's something pre qbit v5.1.2 i don't see why those should be there. 