### PR TITLE
fix: one letter spelling mistake

### DIFF
--- a/src/models/transfer.rs
+++ b/src/models/transfer.rs
@@ -18,7 +18,7 @@ pub struct TransferInfo {
     /// Download rate limit (bytes/s)
     pub dl_rate_limit: i64,
     /// Upload rate limit (bytes/s)
-    pub ul_rate_limit: i64,
+    pub up_rate_limit: i64,
     /// DHT nodes connected to
     pub dht_nodes: i64,
     /// The connection status of qbitt.

--- a/src/parameters.rs
+++ b/src/parameters.rs
@@ -479,7 +479,7 @@ pub struct AddTorrent {
     /// Category for the torrent
     #[builder(setter(into, strip_option), default)]
     pub category: Option<String>,
-    /// Tags for the torrent, split by `,`
+    /// Tags for the torrent.
     #[builder(setter(into, strip_option), default)]
     pub tags: Option<Vec<String>>,
     /// Skip hash checking. Possible values are `true`, `false` (default)


### PR DESCRIPTION
Fixes a one letter spelling mistake which causes a panic otherwise
```rs
called `Result::unwrap()` on an `Err` value: ReqwestError(reqwest::Error { kind: Decode, source: Error("missing field `ul_rate_limit`", line: 1, column: 251) })
```