### PR TITLE
Use enum for tracker state because enums are cool

### DIFF
--- a/src/models/application.rs
+++ b/src/models/application.rs
@@ -296,7 +296,7 @@ pub struct Preferences {
     pub scheduler_days: SchedulerTime,
 
     // ========== BitTorrent Protocol ==========
-    /// Bittorrent Protocol to use (see list of possible values below)
+    /// Bittorrent Protocol to use
     pub bittorrent_protocol: BittorrentProtocol,
     /// Should `dl_limit` be applied to uTP connections?
     ///
@@ -306,7 +306,7 @@ pub struct Preferences {
     pub limit_tcp_overhead: bool,
     /// Should `dl_limit` be applied to peers on the LAN?
     pub limit_lan_peers: bool,
-    /// μTP-TCP mixed mode algorithm (see list of possible values below)
+    /// μTP-TCP mixed mode algorithm
     pub utp_tcp_mixed_mode: UtpTcpMixedMode,
 
     // ========== Peer Discovery ==========

--- a/src/models/torrent.rs
+++ b/src/models/torrent.rs
@@ -456,7 +456,8 @@ pub struct Tracker {
 }
 
 /// Torrent tracker status
-#[derive(Debug, Deserialize, Serialize, Clone, Default, PartialEq)]
+#[derive(Debug, Deserialize_repr, Serialize_repr, Clone, Default, PartialEq)]
+#[repr(u8)]
 pub enum TrackerStatus {
     /// Tracker is disabled (used for DHT, PeX, and LSD)
     #[default]

--- a/src/models/torrent.rs
+++ b/src/models/torrent.rs
@@ -438,7 +438,7 @@ pub struct Tracker {
     /// Tracker url
     pub url: String,
     /// Tracker status.
-    pub status: TrackerState,
+    pub status: TrackerStatus,
     /// Tracker priority tier. Lower tier trackers are tried before higher
     /// tiers. Tier numbers are valid when `>= 0`, `< 0` is used as placeholder
     /// when `tier` does not exist for special entries (such as DHT).
@@ -455,8 +455,9 @@ pub struct Tracker {
     pub msg: String,
 }
 
+/// Torrent tracker status
 #[derive(Debug, Deserialize, Serialize, Clone, Default, PartialEq)]
-pub enum TrackerState {
+pub enum TrackerStatus {
     /// Tracker is disabled (used for DHT, PeX, and LSD)
     #[default]
     Disabled = 0,

--- a/src/models/torrent.rs
+++ b/src/models/torrent.rs
@@ -437,8 +437,8 @@ pub struct TorrentProperties {
 pub struct Tracker {
     /// Tracker url
     pub url: String,
-    /// Tracker status. See the table below for possible values
-    pub status: i64,
+    /// Tracker status.
+    pub status: TrackerState,
     /// Tracker priority tier. Lower tier trackers are tried before higher
     /// tiers. Tier numbers are valid when `>= 0`, `< 0` is used as placeholder
     /// when `tier` does not exist for special entries (such as DHT).
@@ -453,6 +453,21 @@ pub struct Tracker {
     pub num_downloaded: i64,
     /// Tracker message (there is no way of knowing what this message is - it's up to tracker admins)
     pub msg: String,
+}
+
+#[derive(Debug, Deserialize, Serialize, Clone, Default, PartialEq)]
+pub enum TrackerState {
+    /// Tracker is disabled (used for DHT, PeX, and LSD)
+    #[default]
+    Disabled = 0,
+    /// Tracker has not been contacted yet
+    NotContacted = 1,
+    /// Tracker has been contacted and is working
+    Working = 2,
+    /// Tracker is updating
+    Updating = 3,
+    /// Tracker has been contacted, but it is not working (or doesn't send proper replies)
+    NotWorking = 4,
 }
 
 /// Web seed for torrent

--- a/src/parameters.rs
+++ b/src/parameters.rs
@@ -482,10 +482,10 @@ pub struct AddTorrent {
     /// Tags for the torrent.
     #[builder(setter(into, strip_option), default)]
     pub tags: Option<Vec<String>>,
-    /// Skip hash checking. Possible values are `true`, `false` (default)
+    /// Skip hash checking.
     #[builder(default)]
     pub skip_checking: bool,
-    /// Add torrents in the paused state. Possible values are `true`, `false` (default)
+    /// Add torrents in the paused state.
     #[builder(default)]
     pub paused: bool,
     /// The torrent subfolder layout.
@@ -509,10 +509,10 @@ pub struct AddTorrent {
     /// Whether Automatic Torrent Management should be used
     #[builder(default)]
     pub auto_tmm: bool,
-    /// Enable sequential download. Possible values are `true`, `false` (default)
+    /// Enable sequential download.
     #[builder(default)]
     pub sequential_download: bool,
-    /// Prioritize download first last piece. Possible values are `true`, `false` (default)
+    /// Prioritize download first last piece.
     #[builder(default)]
     pub first_last_piece_prio: bool,
 }


### PR DESCRIPTION
This also keeps it consistent with other places where we've changed the type to an enum.

I've also just cleaned up the documentation around `possible values` as it's either self-explanitory or the type's documentation can explain it.


As far as i can tell, this is the last obvious enum replacement. 