### PR TITLE
Consistency. `Torrent.tags` is now of type `Vec<String>`

### DIFF
--- a/src/models/torrent.rs
+++ b/src/models/torrent.rs
@@ -273,6 +273,7 @@ impl<'de> Visitor<'de> for TorrentMapVisitor {
             size: i64,
             state: TorrentState,
             super_seeding: bool,
+            #[serde(deserialize_with = "deserializers::string_to_vec")]
             tags: Vec<String>,
             time_active: i64,
             total_size: i64,

--- a/src/models/torrent.rs
+++ b/src/models/torrent.rs
@@ -156,7 +156,7 @@ pub struct Torrent {
     /// True if super seeding is enabled
     pub super_seeding: bool,
     /// Comma-concatenated tag list of the torrent
-    pub tags: String,
+    pub tags: Vec<String>,
     /// Total active time (seconds)
     pub time_active: i64,
     /// Total size (bytes) of all file in this torrent (including unselected ones)
@@ -272,7 +272,7 @@ impl<'de> Visitor<'de> for TorrentMapVisitor {
             size: i64,
             state: TorrentState,
             super_seeding: bool,
-            tags: String,
+            tags: Vec<String>,
             time_active: i64,
             total_size: i64,
             tracker: String,

--- a/src/models/torrent.rs
+++ b/src/models/torrent.rs
@@ -156,6 +156,7 @@ pub struct Torrent {
     /// True if super seeding is enabled
     pub super_seeding: bool,
     /// Comma-concatenated tag list of the torrent
+    #[serde(deserialize_with = "deserializers::string_to_vec")]
     pub tags: Vec<String>,
     /// Total active time (seconds)
     pub time_active: i64,

--- a/src/utilities/deserializers.rs
+++ b/src/utilities/deserializers.rs
@@ -37,6 +37,17 @@ where
     s.parse::<u64>().map_err(serde::de::Error::custom)
 }
 
+pub fn string_to_vec<'de, D>(deserializer: D) -> Result<Vec<String>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let s = String::deserialize(deserializer)?;
+    Ok(s.split(",")
+        .map(|s| s.trim().to_owned())
+        .filter(|s| !s.is_empty())
+        .collect::<Vec<String>>())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/tests/application/get_directory_contents.rs
+++ b/tests/application/get_directory_contents.rs
@@ -42,5 +42,6 @@ pub async fn list_directory_dirs() {
         .unwrap();
     println!("{:?}", contents);
 
+    // In theory, this should return true because `create_test_data` should have no directories inside, just files.
     assert!(contents.is_empty());
 }

--- a/tests/mod.rs
+++ b/tests/mod.rs
@@ -92,6 +92,15 @@ pub fn create_random_name() -> Option<String> {
     )
 }
 
+/// Create dummy test data file structure
+///
+/// Note: The file provided in environment variables under `temp_dir` will be used as is.
+///     And will not have stuff, like directory checks performend on it.
+///
+/// # Arguments
+///
+/// * `random_name` - A random name to append to the file. Generate one with `create_random_name()`.
+///     The point is so that each individual test can have their own stuff without breaking others.
 pub fn create_test_data(random_name: Option<String>) -> String {
     dotenv().ok();
     // persionally did not want to have to do this, but `/tmp` can cause some issues so...

--- a/tests/mod.rs
+++ b/tests/mod.rs
@@ -159,8 +159,10 @@ pub async fn create_dummy_torrent(
     client.create_task(&torrent).await
 }
 
-pub async fn create_and_get_torrent(client: &Api, random_name: Option<String>) {
-    let task = create_dummy_torrent(client, random_name).await.unwrap();
+pub async fn create_and_get_torrent(client: &Api, random_name: Option<String>) -> Torrent {
+    let task = create_dummy_torrent(client, random_name.clone())
+        .await
+        .unwrap();
 
     let mut list = client.list_tasks().await.unwrap();
     // This should hopefully let the torrent finish creating before attempting to do other stuff.
@@ -186,5 +188,15 @@ pub async fn create_and_get_torrent(client: &Api, random_name: Option<String>) {
         limit -= 1;
     }
 
-    client.torrent(hash)
+    // Annoyingly, qbit doesn't give us much in the ways of linking a torrent task with the actual torrent...
+
+    client
+        .torrents(None)
+        .await
+        .unwrap()
+        .iter()
+        .filter(|t| t.name == random_name.clone().unwrap())
+        .next()
+        .unwrap()
+        .to_owned()
 }

--- a/tests/mod.rs
+++ b/tests/mod.rs
@@ -188,14 +188,24 @@ pub async fn create_and_get_torrent(client: &Api, random_name: Option<String>) -
         limit -= 1;
     }
 
+    // This sleep is just to give extra time for qbit API to update.
+    std::thread::sleep(std::time::Duration::from_secs(1));
+    let root_path = &list
+        .iter()
+        .filter(|v| v.task_id == task)
+        .next()
+        .unwrap()
+        .source_path;
+
     // Annoyingly, qbit doesn't give us much in the ways of linking a torrent task with the actual torrent...
 
-    client
-        .torrents(None)
-        .await
-        .unwrap()
+    let torrents = client.torrents(None).await.unwrap();
+    // println!("{:#?}", torrents);
+
+    // I think root path is more reliable, and besides. Its the only easy thing we can confirm without copying too much code.
+    torrents
         .iter()
-        .filter(|t| t.name == random_name.clone().unwrap())
+        .filter(|t| t.root_path == *root_path)
         .next()
         .unwrap()
         .to_owned()

--- a/tests/mod.rs
+++ b/tests/mod.rs
@@ -1,7 +1,7 @@
 use dotenv::dotenv;
 use qbit::{
     Api,
-    models::{Torrent, TorrentCreatorBuilder, TorrentCreatorTask},
+    models::{TaskStatus, Torrent, TorrentCreatorBuilder, TorrentCreatorTask},
     parameters::AddTorrentBuilder,
 };
 use rand::{Rng, distr::Alphabetic};
@@ -82,6 +82,18 @@ pub async fn get_debian_torrent(client: &Api) -> Option<Torrent> {
         .map(|t| t.to_owned())
 }
 
+/// Creates a random name for use in testing. This HEAVILY reduces the chances of tests failing due to using the same name, at the cost of slightly more compute but it's worth it.
+///
+/// Note: A `Some` is always returned, hence can be unwrapped without issue.
+///
+/// Usage:
+/// ```rs
+/// use crate::{create_random_name};
+///
+/// pub fn test() {
+///     let name = create_random_name().unwrap();
+/// }
+/// ```
 pub fn create_random_name() -> Option<String> {
     Some(
         rand::rng()
@@ -136,4 +148,34 @@ pub async fn create_dummy_torrent(
         .expect("Failed to build torrent creator");
 
     client.create_task(&torrent).await
+}
+
+pub async fn create_and_get_torrent(client: &Api, random_name: Option<String>) {
+    let task = create_dummy_torrent(client, random_name).await.unwrap();
+
+    let mut list = client.list_tasks().await.unwrap();
+    // This should hopefully let the torrent finish creating before attempting to do other stuff.
+    let mut limit = 10;
+    while list
+        .iter()
+        .filter(|v| v.task_id == task)
+        .next()
+        .unwrap()
+        .status
+        != TaskStatus::Finished
+    {
+        println!(
+            "{:?}",
+            list.iter().filter(|v| v.task_id == task).next().unwrap()
+        );
+        if limit == 0 {
+            panic!("Torrent has not finished creating after ~ 10 seconds of checking.");
+        }
+
+        std::thread::sleep(std::time::Duration::from_secs(1));
+        list = client.list_tasks().await.unwrap();
+        limit -= 1;
+    }
+
+    client.torrent(hash)
 }

--- a/tests/torrents/creator.rs
+++ b/tests/torrents/creator.rs
@@ -72,6 +72,15 @@ async fn get_torrent_file() {
     let path = format!("{folder}_data/dummy{}.torrent", random_name.unwrap());
     let data = fs::read(&path).unwrap();
 
+    assert_eq!(
+        client
+            .get_task_file(task)
+            .await
+            .unwrap_or_default()
+            .to_vec(),
+        data
+    );
+
     for item in list.iter() {
         let r = client
             .get_task_file(item.task_id.to_owned())

--- a/tests/torrents/mod.rs
+++ b/tests/torrents/mod.rs
@@ -1,3 +1,4 @@
 pub mod creator;
 pub mod get_torrents;
 pub mod state;
+pub mod tags;

--- a/tests/torrents/tags.rs
+++ b/tests/torrents/tags.rs
@@ -1,4 +1,4 @@
-use crate::{create_dummy_torrent, create_random_name, login_default_client};
+use crate::{create_and_get_torrent, create_random_name, login_default_client};
 
 #[tokio::test]
 #[ignore = "Test hits API endpoint"]
@@ -12,24 +12,29 @@ pub async fn create_empty_tags() {
 #[ignore = "Test hits API endpoint"]
 pub async fn create_random_tags() {
     let client = login_default_client().await;
-    let tags = vec![
-        create_random_name().unwrap(),
-        create_random_name().unwrap(),
-        create_random_name().unwrap(),
-    ];
 
     let result = client
-        .create_tags(tags.iter().map(|t| t.as_ref()).collect())
+        .create_tags(vec![
+            &create_random_name().unwrap(),
+            &create_random_name().unwrap(),
+            &create_random_name().unwrap(),
+        ])
         .await;
     assert!(result.is_ok());
 }
 
 #[tokio::test]
-#[ignore = "Test hits API endpoint"]
+// #[ignore = "Test hits API endpoint"]
 pub async fn create_dummy_with_tags() {
     let client = login_default_client().await;
-    let task = create_dummy_torrent(&client, create_random_name())
+    let random = create_random_name();
+    let torrent = create_and_get_torrent(&client, random).await;
+
+    client
+        .add_tags(
+            Some(vec![&torrent.hash]),
+            vec![&create_random_name().unwrap()],
+        )
         .await
         .unwrap();
-    let task_as_torrent = client.list_tasks().await.unwrap();
 }

--- a/tests/torrents/tags.rs
+++ b/tests/torrents/tags.rs
@@ -1,0 +1,35 @@
+use crate::{create_dummy_torrent, create_random_name, login_default_client};
+
+#[tokio::test]
+#[ignore = "Test hits API endpoint"]
+pub async fn create_empty_tags() {
+    let client = login_default_client().await;
+    let result = client.create_tags(vec![""]).await;
+    assert!(result.is_ok());
+}
+
+#[tokio::test]
+#[ignore = "Test hits API endpoint"]
+pub async fn create_random_tags() {
+    let client = login_default_client().await;
+    let tags = vec![
+        create_random_name().unwrap(),
+        create_random_name().unwrap(),
+        create_random_name().unwrap(),
+    ];
+
+    let result = client
+        .create_tags(tags.iter().map(|t| t.as_ref()).collect())
+        .await;
+    assert!(result.is_ok());
+}
+
+#[tokio::test]
+#[ignore = "Test hits API endpoint"]
+pub async fn create_dummy_with_tags() {
+    let client = login_default_client().await;
+    let task = create_dummy_torrent(&client, create_random_name())
+        .await
+        .unwrap();
+    let task_as_torrent = client.list_tasks().await.unwrap();
+}

--- a/tests/torrents/tags.rs
+++ b/tests/torrents/tags.rs
@@ -1,5 +1,8 @@
+use qbit::parameters::TorrentListParamsBuilder;
+
 use crate::{create_and_get_torrent, create_random_name, login_default_client};
 
+/// Tests to see if creating tags is fine.
 #[tokio::test]
 #[ignore = "Test hits API endpoint"]
 pub async fn create_empty_tags() {
@@ -8,6 +11,7 @@ pub async fn create_empty_tags() {
     assert!(result.is_ok());
 }
 
+/// Tests to see if creating random tags is fine.
 #[tokio::test]
 #[ignore = "Test hits API endpoint"]
 pub async fn create_random_tags() {
@@ -23,18 +27,69 @@ pub async fn create_random_tags() {
     assert!(result.is_ok());
 }
 
+/// Tests to see if we can create a torrent, add tags to it, and find it when we filter for just those tags.
 #[tokio::test]
-// #[ignore = "Test hits API endpoint"]
+#[ignore = "Test hits API endpoint"]
 pub async fn create_dummy_with_tags() {
     let client = login_default_client().await;
     let random = create_random_name();
     let torrent = create_and_get_torrent(&client, random).await;
+    let tag_name = create_random_name().unwrap();
+
+    client
+        .add_tags(Some(vec![&torrent.hash]), vec![&tag_name])
+        .await
+        .unwrap();
+
+    // Assuming that the random name is random.
+    assert_eq!(
+        client
+            .torrents(Some(
+                TorrentListParamsBuilder::default()
+                    .tag(tag_name)
+                    .build()
+                    .unwrap(),
+            ))
+            .await
+            .unwrap()
+            .len(),
+        1
+    );
+}
+
+/// Test to see other tags are being added correctly.
+#[tokio::test]
+#[ignore = "Test hits API endpoint"]
+pub async fn get_tags() {
+    let client = login_default_client().await;
+    let random = create_random_name();
+    let torrent = create_and_get_torrent(&client, random).await;
+    let tag_name = create_random_name().unwrap();
+    let tag_name2 = create_random_name().unwrap();
+    let tag_name3 = create_random_name().unwrap();
 
     client
         .add_tags(
             Some(vec![&torrent.hash]),
-            vec![&create_random_name().unwrap()],
+            vec![&tag_name, &tag_name2, &tag_name3],
         )
         .await
         .unwrap();
+
+    let torrents = client
+        .torrents(Some(
+            TorrentListParamsBuilder::default()
+                .tag(tag_name)
+                .build()
+                .unwrap(),
+        ))
+        .await
+        .unwrap();
+
+    // Assuming that the random name is random.
+    assert_eq!(torrents.len(), 1);
+
+    let torrent = torrents.first().unwrap();
+    assert!(torrent.tags.contains(&tag_name2));
+    assert!(torrent.tags.contains(&tag_name3));
 }


### PR DESCRIPTION
Basically moves the job of doing:
```rs
.split(",")
.map(|s| s.trim().to_owned())
.filter(|s| !s.is_empty())
.collect::<Vec<String>>())
```
into the crate instead of on the user. Downside is, user will need to do `.iter()` instead of following on from `.filter()` but everything else in the crate related to tags uses `Vec<String>` so i see no reason why `Torrent` should as well.

Tests updated with additional comments, and new tests just to make sure it works.