### PR TITLE
fix(trackers): ability to add multiple trackers

### DIFF
--- a/src/client/torrent.rs
+++ b/src/client/torrent.rs
@@ -683,7 +683,7 @@ impl super::Api {
     pub async fn add_trackers_to_torrent(&self, hash: &str, urls: Vec<&str>) -> Result<(), Error> {
         let form = multipart::Form::new()
             .text("hash", hash.to_string())
-            .text("urls", urls.join("%0A"));
+            .text("urls", urls.join("\n"));
 
         self._post("torrents/addTrackers")
             .await?


### PR DESCRIPTION
I only noticed this because my trackers were appearing as 
```
http://nyaa.tracker.wf:7777/announce%0Audp://open.stealth.si:80/announce%0Audp://tracker.opentrackr.org:1337/announce%0Audp://exodus.desync.com:6969/announce%0Audp://tracker.torrent.eu.org:451/announce
```
instead of
```
http://nyaa.tracker.wf:7777/announce
udp://open.stealth.si:80/announce
udp://tracker.opentrackr.org:1337/announce
udp://exodus.desync.com:6969/announce
Audp://tracker.torrent.eu.org:451/announce
```
and after (not too much but not a bit) of debugging, (failed to try the obvious), found that reqwests automatically encodes the URL, hence `%0A` wasn't actually being kept as `%0A`. And `\n` is what we needed to use.