### PR TITLE
TorrentListParams: make reverse optional

### DIFF
--- a/src/client/torrent.rs
+++ b/src/client/torrent.rs
@@ -47,7 +47,9 @@ impl super::Api {
 
         let params = params.unwrap_or_default();
 
-        query.push(("reverse", params.reverse.to_string()));
+        if let Some(reverse) = params.reverse {
+            query.push(("reverse", reverse.to_string()));
+        }
         if let Some(filter) = params.filter {
             query.push(("filter", filter.to_string()));
         }

--- a/src/parameters.rs
+++ b/src/parameters.rs
@@ -24,9 +24,9 @@ pub struct TorrentListParams {
     /// Sort torrents by given key. They can be sorted using any field of the response's JSON array (see `TorrentSort`) as the sort key.
     #[builder(setter(strip_option), default)]
     pub sort: Option<TorrentSort>,
-    /// Enable reverse sorting. Defaults to `false`
-    #[builder(default)]
-    pub reverse: bool,
+    /// Enable reverse sorting. Defaults to `false` if not set
+    #[builder(setter(strip_option), default)]
+    pub reverse: Option<bool>,
     /// Limit the number of torrents returned
     #[builder(setter(into, strip_option), default)]
     pub limit: Option<i64>,


### PR DESCRIPTION
Right now every request to `api/v2/torrents/info` contains the get parameter `?reverse=false` which is the default so it is useless to send it every time.
Also in the (unlikely) case qBittorrent changes the default in the future this library wouldn't be compatible anymore because it would stay on the old default...