### PR TITLE
Fixes and changes for Qbittorrent 5.2+ compatibility

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,14 @@
+# Test server url
+url = http://localhost
+# Test server port
+port = 6881
+# Test server username
+username = admin
+# Test server password
+password = adminadmin
+# Directory for temporary test files
+temp_dir = .temp
+# For testing, the temporary directory should be mirrored on the test server and
+# the api wrapper. This is the path used on the server to find the files. If it
+# is running as the same user on the same machine, it can be the same as `temp_dir`
+server_temp_dir = .temp

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -12,7 +12,8 @@ jobs:
       url: http://localhost
       port: 45378
       username: admin
-      temp_dir: .temp
+      temp_dir: /home/runner/.temp
+      server_temp_dir: /home/runner/.temp
 
       encrypted_password: "@ByteArray(ARQ77eY1NUZaQsuDHbIMCA==:0WMRkYTUWVT9wVvdDtHAjU9b3b7uB8NR1Gur2hmQCvCDpm39Q+PsJRJPaCU51dEiz+dTzh8qbPsL8WkFljQYFQ==)"
       password: adminadmin
@@ -47,6 +48,9 @@ jobs:
 
       - name: Setup rust
         uses: actions-rust-lang/setup-rust-toolchain@v1
+
+      - name: Show working directory for testing
+        run: pwd
 
       - name: Run tests
         run: |

--- a/src/client/authentication.rs
+++ b/src/client/authentication.rs
@@ -141,19 +141,30 @@ impl super::Api {
         }
 
         let mut state = self.state.write().await;
+        let cookie = sid
+            .unwrap()
+            .to_str()
+            .map_err(|e| {
+                Error::AuthFailed(format!("Failed to pars SID cookie to str. err: {}", e))
+            })?
+            .split(';')
+            .next()
+            .ok_or(Error::AuthFailed("Failed to parse SID cookie".to_string()))?
+            .to_string();
+
+        // Check if the cookie starts with "SID" or "QBT_SID" to validate it
+        // qbittorrent version >=5.2 vill return QBT_SID_<PORT>
+        // qbittorrent version < 5.2 will return SID
+        // refer https://github.com/qbittorrent/qBittorrent/issues/24190
+        if !(cookie.starts_with("SID") || cookie.starts_with("QBT_SID")) {
+            return Err(Error::AuthFailed(
+                "Login failed no valid SID cookie received".to_string(),
+            ));
+        }
+
         *state = LoginState::LoggedIn {
             credentials: state.as_credentials().unwrap().clone(),
-            cookie_sid: sid
-                .unwrap()
-                .to_str()
-                .map_err(|e| {
-                    Error::AuthFailed(format!("Failed to pars SID cookie to str. err: {}", e))
-                })?
-                .split(';')
-                .next()
-                .ok_or(Error::AuthFailed("Failed to parse SID cookie".to_string()))?
-                .trim_start_matches("SID=")
-                .to_string(),
+            cookie_sid: cookie,
         };
 
         Ok(())

--- a/src/client/authentication.rs
+++ b/src/client/authentication.rs
@@ -153,7 +153,7 @@ impl super::Api {
             .to_string();
 
         // Check if the cookie starts with "SID" or "QBT_SID" to validate it
-        // qbittorrent version >=5.2 vill return QBT_SID_<PORT>
+        // qbittorrent version >=5.2 will return QBT_SID_<PORT>
         // qbittorrent version < 5.2 will return SID
         // refer https://github.com/qbittorrent/qBittorrent/issues/24190
         if !(cookie.starts_with("SID") || cookie.starts_with("QBT_SID")) {

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -64,7 +64,7 @@ impl Api {
     async fn _post(&self, endpoint: &str) -> Result<RequestBuilder, Error> {
         let mut header_map = HeaderMap::new();
         if let Some(cookie) = self.state.read().await.as_cookie() {
-            let cookie = format!("SID={}; HttpOnly; SameSite=Strict; path=/", cookie);
+            let cookie = format!("{}; HttpOnly; SameSite=Strict; path=/", cookie);
             header_map.insert(header::COOKIE, cookie.parse().unwrap());
         }
 
@@ -78,7 +78,7 @@ impl Api {
     async fn _get(&self, endpoint: &str) -> Result<RequestBuilder, Error> {
         let mut header_map = HeaderMap::new();
         if let Some(cookie) = self.state.read().await.as_cookie() {
-            let cookie = format!("SID={}; HttpOnly; SameSite=Strict; path=/", cookie);
+            let cookie = format!("{}; HttpOnly; SameSite=Strict; path=/", cookie);
             header_map.insert(header::COOKIE, cookie.parse().unwrap());
         }
 

--- a/src/models/sync.rs
+++ b/src/models/sync.rs
@@ -116,7 +116,7 @@ pub struct ServerState {
     /// Alt speed enabeld
     pub use_alt_speed_limits: bool,
     /// Use subcategories
-    pub use_subcategories: bool,
+    pub use_subcategories: Option<bool>,
     /// How overloaded is the read cache.
     ///
     /// Calculated by write queue size / peer count

--- a/tests/application/get_directory_contents.rs
+++ b/tests/application/get_directory_contents.rs
@@ -1,3 +1,5 @@
+use std::{env, fs};
+
 use crate::{create_test_data, login_default_client};
 use qbit::models::DirMode;
 
@@ -6,41 +8,60 @@ use qbit::models::DirMode;
 #[tokio::test]
 #[ignore = "Test hits api endpoint"]
 pub async fn list_directory() {
-    let folder = create_test_data(None);
+    let folder = create_test_data();
     let client = login_default_client().await;
     let contents = client
-        .get_directory_contents(&folder, &DirMode::default())
+        .get_directory_contents(&format!("{folder}/dummy"), &DirMode::default())
         .await
         .unwrap();
     println!("{:?}", contents);
 
-    assert!(contents.contains(&format!("{folder}/dummy.txt")));
+    assert!(contents.contains(&format!("{folder}/dummy/dummy.txt")));
 }
 
 #[tokio::test]
 #[ignore = "Test hits api endpoint"]
 pub async fn list_directory_files() {
-    let folder = create_test_data(None);
+    let folder = create_test_data();
     let client = login_default_client().await;
     let contents = client
-        .get_directory_contents(&folder, &DirMode::Files)
+        .get_directory_contents(&format!("{folder}/dummy"), &DirMode::Files)
         .await
         .unwrap();
     println!("{:?}", contents);
 
-    assert!(contents.contains(&format!("{folder}/dummy.txt")));
+    assert!(contents.contains(&format!("{folder}/dummy/dummy.txt")));
 }
 
 #[tokio::test]
 #[ignore = "Test hits api endpoint"]
 pub async fn list_directory_dirs() {
-    let folder = create_test_data(None);
+    let folder = create_test_data();
+    let temp_dir = env::var("temp_dir").unwrap();
+    if fs::exists(format!("{temp_dir}/dir_test_empty_list")).unwrap() {
+        fs::remove_dir_all(format!("{temp_dir}/dir_test_empty_list")).unwrap();
+    }
+    fs::create_dir(format!("{temp_dir}/dir_test_empty_list")).unwrap_or_default();
     let client = login_default_client().await;
     let contents = client
-        .get_directory_contents(&folder, &DirMode::Dirs)
+        .get_directory_contents(&format!("{folder}/dir_test_empty_list"), &DirMode::All)
         .await
         .unwrap();
     println!("{:?}", contents);
 
     assert!(contents.is_empty());
+}
+
+#[tokio::test]
+#[ignore = "Test hits api endpoint"]
+pub async fn list_directory_dirs_not_empty() {
+    let folder = create_test_data();
+    let client = login_default_client().await;
+    let contents = client
+        .get_directory_contents(&format!("{folder}/dummy"), &DirMode::All)
+        .await
+        .unwrap();
+    println!("{:?}", contents);
+
+    assert!(!contents.is_empty());
 }

--- a/tests/mod.rs
+++ b/tests/mod.rs
@@ -5,7 +5,7 @@ use qbit::{
     parameters::AddTorrentBuilder,
 };
 use rand::{Rng, distr::Alphabetic};
-use std::{env, fs, path};
+use std::{env, fs};
 
 pub mod application;
 pub mod authentication;
@@ -14,6 +14,9 @@ pub mod torrents;
 
 pub const DEBIAN_HASH: &str = "6f4370df4304609a8793ce2b59178dcc8febf5e2";
 pub const DEBIAN_TRACKER: &str = "magnet:?xt=urn:btih:6f4370df4304609a8793ce2b59178dcc8febf5e2&dn=debian-12.11.0-amd64-netinst.iso&xl=702545920&tr=http%3A%2F%2Fbttracker.debian.org%3A6969%2Fannounce&ws=https://cdimage.debian.org/cdimage/archive/12.11.0/amd64/iso-cd/debian-12.11.0-amd64-netinst.iso&ws=https://cdimage.debian.org/cdimage/release/12.11.0/amd64/iso-cd/debian-12.11.0-amd64-netinst.iso";
+
+// Relative path to the dummy file within the test data directory.
+const DUMMY_FILE: &str = "dummy/dummy.txt";
 
 pub fn get_server_details() -> String {
     dotenv().ok();
@@ -58,6 +61,10 @@ pub async fn add_debian_torrent(client: &Api) {
         .build()
         .expect("Failed to build AddTorrent");
 
+    if client.torrent(DEBIAN_HASH).await.is_ok() {
+        return;
+    }
+
     client
         .add_torrent(param)
         .await
@@ -82,56 +89,82 @@ pub async fn get_debian_torrent(client: &Api) -> Option<Torrent> {
         .map(|t| t.to_owned())
 }
 
-pub fn create_random_name() -> Option<String> {
-    Some(
-        rand::rng()
-            .sample_iter(&Alphabetic)
-            .take(7)
-            .map(char::from)
-            .collect::<String>(),
-    )
+pub fn create_random_name(prefix: &str) -> String {
+    let name = rand::rng()
+        .sample_iter(&Alphabetic)
+        .take(7)
+        .map(char::from)
+        .collect::<String>();
+    format!("{prefix}{name}")
 }
 
-pub fn create_test_data(random_name: Option<String>) -> String {
+// NOTE: The random name is ignored and a dummy file is always created.
+pub fn create_test_data() -> String {
     dotenv().ok();
+    if env::var("temp_dir").is_err() {
+        panic!("'temp_dir' not set. Required for test data creation.");
+    }
+    if env::var("server_temp_dir").is_err() {
+        panic!("'server_temp_dir' not set. Required for test data creation.");
+    }
+
     // persionally did not want to have to do this, but `/tmp` can cause some issues so...
-    let folder = format!(
-        "{}{}",
-        env::var("temp_dir").unwrap(),
-        random_name.clone().unwrap_or_default()
-    );
-
-    if !fs::exists(&folder).unwrap() {
-        fs::create_dir(&folder).unwrap_or_default();
+    // Create the temp directory if it doesn't exist
+    let folder = env::var("temp_dir").unwrap();
+    if !fs::exists(format!("{folder}")).unwrap() {
+        fs::create_dir(format!("{folder}")).unwrap_or_default();
     }
-    if !fs::exists(format!("{folder}_data")).unwrap() {
-        fs::create_dir(format!("{folder}_data")).unwrap_or_default();
+    if !fs::exists(format!("{folder}/dummy")).unwrap() {
+        fs::create_dir(format!("{folder}/dummy")).unwrap_or_default();
+    }
+    if !fs::exists(format!("{folder}/_data")).unwrap() {
+        fs::create_dir(format!("{folder}/_data")).unwrap_or_default();
     }
 
-    fs::write(
-        format!("{folder}/dummy{}.txt", random_name.unwrap_or_default()),
-        "This is a dummy file. You are a dummy for downloading this file.",
-    )
-    .expect("Failed to write dummy file");
+    // Create dummy file if it doesn't exist
+    if !fs::exists(format!("{folder}/dummy/dummy.txt")).unwrap() {
+        fs::write(
+            format!("{folder}/{DUMMY_FILE}"),
+            "This is a dummy file. You are a dummy for downloading this file.",
+        )
+        .expect("Failed to write dummy file");
+    }
 
-    path::absolute(folder).unwrap().display().to_string()
+    // Edited so that the folder path is returned as the server temporary test directory
+    // path::absolute(folder).unwrap().display().to_string()
+    env::var("server_temp_dir").unwrap()
 }
 
 pub async fn create_dummy_torrent(
     client: &Api,
-    random_name: Option<String>,
+    name: String,
 ) -> Result<TorrentCreatorTask, qbit::Error> {
-    let folder = create_test_data(random_name.clone());
+    let server_folder = create_test_data();
+    let folder = format!("{}/_data/{name}", env::var("temp_dir").unwrap());
+    fs::create_dir_all(&folder).unwrap_or_default();
+    println!(
+        "{} : {}",
+        format!("{}/{DUMMY_FILE}", env::var("temp_dir").unwrap()),
+        format!("{folder}/dummy.txt")
+    );
+    println!(
+        "{:?} : {:?}",
+        fs::exists(format!("{}/{DUMMY_FILE}", env::var("temp_dir").unwrap())),
+        fs::exists(format!("{folder}/dummy.txt"))
+    );
+    fs::copy(
+        format!("{}/{DUMMY_FILE}", env::var("temp_dir").unwrap()),
+        format!("{folder}/dummy.txt"),
+    )
+    .unwrap();
+
     let torrent = TorrentCreatorBuilder::default()
-        .source_path(&folder)
+        .source_path(format!("{server_folder}/_data/{name}"))
         .start_seeding(true)
         .private(true)
         .comment("Dummy comment for a dummy torrent")
         .source("https://example.com/dummy")
-        .torrent_file_path(format!(
-            "{folder}_data/dummy{}.torrent",
-            random_name.unwrap_or_default()
-        ))
+        .torrent_file_path(format!("{server_folder}/_data/{name}.torrent"))
         .build()
         .expect("Failed to build torrent creator");
 

--- a/tests/torrents/creator.rs
+++ b/tests/torrents/creator.rs
@@ -3,18 +3,37 @@ use qbit::{
     models::{TaskStatus, TorrentCreatorBuilder},
 };
 
-use crate::{create_dummy_torrent, create_random_name, login_default_client};
-use std::{env, fs};
+use crate::{create_dummy_torrent, create_random_name, create_test_data, login_default_client};
+use std::{env, fs, thread, time::Duration};
 
 /// This test makes sure that the endpoint can create a dummy task.
 #[tokio::test]
 #[ignore = "Test hits api endpoint"]
 async fn create_task() {
     let client = login_default_client().await;
-    let random_name = create_random_name();
-    let result = create_dummy_torrent(&client, random_name).await;
+    let random_name = create_random_name("create1_");
+    let result = create_dummy_torrent(&client, random_name.clone()).await;
 
     assert!(result.is_ok());
+
+    // Clean up
+    thread::sleep(Duration::from_secs(1));
+    client.delete_task(result.unwrap()).await.unwrap();
+    let hash = client
+        .torrents(None)
+        .await
+        .unwrap()
+        .iter()
+        .filter(|t| t.name == random_name)
+        .next()
+        .map(|t| t.hash.clone())
+        .unwrap();
+    client.delete(vec![&hash], true).await.unwrap();
+    fs::remove_file(format!(
+        "{}/_data/{random_name}.torrent",
+        env::var("temp_dir").unwrap()
+    ))
+    .unwrap();
 }
 
 /// This test makes sure that the list shows the dummy task we've just created.
@@ -22,11 +41,27 @@ async fn create_task() {
 #[ignore = "Test hits api endpoint"]
 async fn list_tasks() {
     let client = login_default_client().await;
-    let random_name = create_random_name();
-    let result = create_dummy_torrent(&client, random_name).await.unwrap();
+    let random_name = create_random_name("list1_");
+    let result = create_dummy_torrent(&client, random_name.clone())
+        .await
+        .unwrap();
     let list = client.list_tasks().await.unwrap();
     assert!(!list.is_empty());
     assert!(list.iter().any(|t| t.task_id == result));
+
+    // Clean up
+    thread::sleep(Duration::from_secs(1));
+    client.delete_task(result).await.unwrap();
+    fs::remove_dir_all(format!(
+        "{}/_data/{random_name}",
+        env::var("temp_dir").unwrap()
+    ))
+    .unwrap();
+    fs::remove_file(format!(
+        "{}/_data/{random_name}.torrent",
+        env::var("temp_dir").unwrap()
+    ))
+    .unwrap();
 }
 
 /// Tests to see that upon the torrent being finished, it is the same as the information we have in the dummy file.
@@ -34,7 +69,8 @@ async fn list_tasks() {
 #[ignore = "Test hits api endpoint"]
 async fn get_torrent_file() {
     let client = login_default_client().await;
-    let random_name = create_random_name();
+    let random_name = create_random_name("get1_");
+    create_test_data();
     let task = create_dummy_torrent(&client, random_name.clone())
         .await
         .unwrap();
@@ -64,12 +100,11 @@ async fn get_torrent_file() {
         limit -= 1;
     }
 
-    let folder = format!(
-        "{}{}",
-        env::var("temp_dir").unwrap(),
-        random_name.clone().unwrap()
+    // let folder = format!("{server_folder}", env::var("temp_dir").unwrap());
+    let path = format!(
+        "{}/_data/{random_name}.torrent",
+        env::var("temp_dir").unwrap()
     );
-    let path = format!("{folder}_data/dummy{}.torrent", random_name.unwrap());
     let data = fs::read(&path).unwrap();
 
     for item in list.iter() {
@@ -82,6 +117,24 @@ async fn get_torrent_file() {
             assert!(true);
         }
     }
+
+    // Clean up
+    thread::sleep(Duration::from_secs(1));
+    let hash = client
+        .torrents(None)
+        .await
+        .unwrap()
+        .iter()
+        .filter(|t| t.name == random_name)
+        .next()
+        .map(|t| t.hash.clone())
+        .unwrap();
+    client.delete(vec![&hash], true).await.unwrap();
+    fs::remove_file(format!(
+        "{}/_data/{random_name}.torrent",
+        env::var("temp_dir").unwrap()
+    ))
+    .unwrap();
 }
 
 /// Make sure that we can delete the created task.
@@ -89,8 +142,10 @@ async fn get_torrent_file() {
 #[ignore = "Test hits api endpoint"]
 async fn delete_created_task() {
     let client = login_default_client().await;
-    let random_name = create_random_name();
-    let task_id = create_dummy_torrent(&client, random_name).await.unwrap();
+    let random_name = create_random_name("delete1_");
+    let task_id = create_dummy_torrent(&client, random_name.clone())
+        .await
+        .unwrap();
     let list = client.list_tasks().await.unwrap();
     assert!(!list.is_empty());
     assert!(list.iter().any(|t| t.task_id == task_id));
@@ -100,6 +155,14 @@ async fn delete_created_task() {
         .expect("Failed to delete task");
     let list = client.list_tasks().await.unwrap();
     assert!(!list.iter().any(|t| t.task_id == task_id));
+
+    thread::sleep(Duration::from_secs(1));
+    fs::remove_dir_all(format!(
+        "{}/_data/{}",
+        env::var("temp_dir").unwrap(),
+        random_name
+    ))
+    .unwrap();
 }
 
 /// Test to check failed to create errors


### PR DESCRIPTION
* In Qbittorrent 5.2, the key name for session cookies changed from SID to QBT_SID_{WebUI PORT} . See [Qbittorrent PR 23228](https://github.com/qbittorrent/qBittorrent/pull/23228) and [Qbittorrent ISSUE 21651](https://github.com/qbittorrent/qBittorrent/issues/21651)
  * The implemented solution removes explicit SID parsing, since the only expected cookie returned during login is the SID, and stores the key name and value for header requests.
* Added a new check to the login that looks for either the cookies that start with SID or QBT_SID
* Fixed some issues, mainly during GitHub action and my testing environment, where files were inaccessible for testing of torrent creation and directory list.
* In Qbittorrent >=5.2, the model ServerState now includes use_subcategories as an option<bool> and not a bool.
