### PR TITLE
Fixed bug where `server_state.global_ratio` return `-`

### DIFF
--- a/src/client/sync.rs
+++ b/src/client/sync.rs
@@ -38,15 +38,25 @@ impl super::Api {
             query.push(("rid", rid));
         }
 
-        let data = self
+        let resp = self
             ._get("sync/maindata")
             .await?
             .query(&query)
             .send()
             .await?
-            .error_for_status()?
-            .json::<MainData>()
-            .await?;
+            .error_for_status()?;
+
+        let body = resp.text().await?;
+        // Attempt to deserialize, but include the body in any error for debugging
+        let data: MainData = match serde_json::from_str(&body) {
+            Ok(d) => d,
+            Err(e) => {
+                return Err(Error::InvalidResponse(format!(
+                    "Failed to deserialize MainData: {}. body: {}",
+                    e, body
+                )));
+            }
+        };
 
         Ok(data)
     }

--- a/src/utilities/deserializers.rs
+++ b/src/utilities/deserializers.rs
@@ -1,4 +1,5 @@
 use serde::{Deserialize, Deserializer};
+use serde_json::Value as JsonValue;
 
 /// Deserializes a field from a JSON value that might be `null`.
 ///
@@ -25,16 +26,52 @@ pub fn string_to_f64<'de, D>(deserializer: D) -> Result<f64, D::Error>
 where
     D: serde::Deserializer<'de>,
 {
-    let s = String::deserialize(deserializer)?;
-    s.parse::<f64>().map_err(serde::de::Error::custom)
+    let v = JsonValue::deserialize(deserializer)?;
+
+    match v {
+        JsonValue::Number(n) => n
+            .as_f64()
+            .ok_or_else(|| serde::de::Error::custom("invalid number for f64")),
+        JsonValue::String(s) => {
+            let t = s.trim();
+            if t.is_empty() || t == "-" {
+                Ok(0.0)
+            } else {
+                s.parse::<f64>().map_err(serde::de::Error::custom)
+            }
+        }
+        JsonValue::Null => Ok(0.0),
+        other => Err(serde::de::Error::custom(format!(
+            "unexpected type for f64 deserialization: {:?}",
+            other
+        ))),
+    }
 }
 
 pub fn string_to_u64<'de, D>(deserializer: D) -> Result<u64, D::Error>
 where
     D: serde::Deserializer<'de>,
 {
-    let s = String::deserialize(deserializer)?;
-    s.parse::<u64>().map_err(serde::de::Error::custom)
+    let v = JsonValue::deserialize(deserializer)?;
+
+    match v {
+        JsonValue::Number(n) => n
+            .as_u64()
+            .ok_or_else(|| serde::de::Error::custom("invalid number for u64")),
+        JsonValue::String(s) => {
+            let t = s.trim();
+            if t.is_empty() || t == "-" {
+                Ok(0)
+            } else {
+                s.parse::<u64>().map_err(serde::de::Error::custom)
+            }
+        }
+        JsonValue::Null => Ok(0),
+        other => Err(serde::de::Error::custom(format!(
+            "unexpected type for u64 deserialization: {:?}",
+            other
+        ))),
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
When `server_state.global_ratio` is not set, the Qbittorrent client returns `-`. The deserializer expected valid data and threw an error otherwise.

Added checks for JSON values in the deserializers and assumed that null and `-` mean `0.0`


```Failed to fetch main data: : InvalidResponse("Failed to deserialize MainData: invalid float literal at line 1 column 252. body: {\"full_update\":true,
\"rid\":1,
\"server_state\": {
  \"alltime_dl\":0,
  \"alltime_ul\":0,
  \"average_time_queue\":0,
  \"connection_status\":\"disconnected\",
  \"dht_nodes\":0,
  \"dl_info_data\":0,
  \"dl_info_speed\":0,
  \"dl_rate_limit\":0,
  \"free_space_on_disk\":1298961403904,
  \"global_ratio\":\"-\",             <===== THIS VALUE
  \"last_external_address_v4\":\"\",
  \"last_external_address_v6\":\"\",
===SNIP===```